### PR TITLE
docs: rename Moltbot → OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tlon Skill
 
-A [Moltbot](https://github.com/moltbot/moltbot) skill for interacting with Tlon/Urbit beyond the channel plugin.
+A [OpenClaw](https://github.com/openclaw/openclaw) skill for interacting with Tlon/Urbit beyond the channel plugin.
 
 ## Features
 
@@ -11,7 +11,7 @@ A [Moltbot](https://github.com/moltbot/moltbot) skill for interacting with Tlon/
 - **Messages**: Fetch message history with quote/cite resolution
 - **Activity**: View mentions, replies, and unread notifications
 - **Contacts**: List, get, and update contact profiles
-- **Settings**: Hot-reload Moltbot plugin config via settings-store
+- **Settings**: Hot-reload OpenClaw plugin config via settings-store
 
 ## Installation
 
@@ -26,7 +26,7 @@ npm install
 
 ## Configuration
 
-Set environment variables or configure in your Moltbot setup:
+Set environment variables or configure in your OpenClaw setup:
 
 ```bash
 export URBIT_URL="https://your-ship.tlon.network"
@@ -34,7 +34,7 @@ export URBIT_SHIP="~your-ship"
 export URBIT_CODE="sampel-ticlyt-migfun-falmel"  # Your +code
 ```
 
-The skill also reads credentials from Moltbot's config if environment variables aren't set.
+The skill also reads credentials from OpenClaw's config if environment variables aren't set.
 
 ---
 
@@ -247,9 +247,9 @@ npx ts-node scripts/contacts.ts update-profile --avatar "https://example.com/ava
 
 ---
 
-## Settings (Moltbot Plugin Config)
+## Settings (OpenClaw Plugin Config)
 
-Manage Moltbot's Tlon plugin config via Urbit settings-store. Changes apply immediately without gateway restart.
+Manage OpenClaw's Tlon plugin config via Urbit settings-store. Changes apply immediately without gateway restart.
 
 ```bash
 # View current settings
@@ -302,7 +302,7 @@ npx ts-node scripts/notebook-post.ts ~host/group diary/~host/channel "Post Title
 
 ## Complements the Tlon Plugin
 
-This skill handles API operations, history retrieval, and administration. For real-time messaging and bot responses, use the [Tlon channel plugin](https://github.com/tloncorp/moltbot-tlon).
+This skill handles API operations, history retrieval, and administration. For real-time messaging and bot responses, use the [Tlon channel plugin](https://github.com/tloncorp/openclaw-tlon).
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -338,9 +338,9 @@ Content format is Tlon's Story structure - an array of verses:
 ]
 ```
 
-### Moltbot Settings (Hot-Reload Config)
+### OpenClaw Settings (Hot-Reload Config)
 
-Manage Moltbot's Tlon plugin settings via Urbit's settings-store. Changes apply immediately without gateway restart.
+Manage OpenClaw's Tlon plugin settings via Urbit's settings-store. Changes apply immediately without gateway restart.
 
 **View current settings:**
 ```bash
@@ -394,5 +394,5 @@ See [references/urbit-api.md](references/urbit-api.md) for Urbit HTTP API detail
 - All ship names should include the `~` prefix (scripts will normalize if missing)
 - Profile updates sync to peers automatically via the contacts agent
 - Post IDs are Unix timestamps in milliseconds
-- For sending messages via the Moltbot message tool, use `channel=tlon`
+- For sending messages via the OpenClaw message tool, use `channel=tlon`
 - Channel nests follow format: `<kind>/~<host>/<name>` where kind is chat, diary, or heap

--- a/scripts/settings.ts
+++ b/scripts/settings.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env npx ts-node
 /**
- * Manage Moltbot settings in Urbit settings-store.
+ * Manage OpenClaw settings in Urbit settings-store.
  * 
  * Usage:
  *   npx ts-node scripts/settings.ts get
@@ -256,7 +256,7 @@ async function main() {
       }
       
       default:
-        console.log(`Moltbot Settings Manager
+        console.log(`OpenClaw Settings Manager
 
 Commands:
   get                              Show all settings

--- a/scripts/urbit-client.ts
+++ b/scripts/urbit-client.ts
@@ -17,12 +17,15 @@ let config: UrbitConfig | null = null;
 let authCookie: string | null = null;
 
 /**
- * Try to read Tlon credentials from Moltbot config
+ * Try to read Tlon credentials from OpenClaw config
  */
-function getConfigFromMoltbot(): UrbitConfig | null {
-  // Check common Moltbot config locations
+function getConfigFromOpenClaw(): UrbitConfig | null {
+  // Check common OpenClaw config locations (with moltbot fallback)
   const configPaths = [
-    process.env.MOLTBOT_CONFIG,
+    process.env.OPENCLAW_CONFIG,
+    path.join(os.homedir(), '.openclaw', 'openclaw.yaml'),
+    path.join(os.homedir(), '.openclaw', 'openclaw.json'),
+    // Legacy paths for backwards compatibility
     path.join(os.homedir(), '.clawdbot', 'moltbot.json'),
     path.join(os.homedir(), '.moltbot', 'moltbot.json'),
   ].filter(Boolean) as string[];
@@ -51,7 +54,7 @@ function getConfigFromMoltbot(): UrbitConfig | null {
 }
 
 /**
- * Get config from environment variables, or fall back to Moltbot config
+ * Get config from environment variables, or fall back to OpenClaw config
  */
 export function getConfig(): UrbitConfig {
   // 1. Check environment variables first
@@ -63,16 +66,16 @@ export function getConfig(): UrbitConfig {
     return { url, ship: ship.replace(/^~/, ""), code };
   }
 
-  // 2. Fall back to Moltbot config
-  const moltbotConfig = getConfigFromMoltbot();
-  if (moltbotConfig) {
-    return moltbotConfig;
+  // 2. Fall back to OpenClaw config
+  const openclawConfig = getConfigFromOpenClaw();
+  if (openclawConfig) {
+    return openclawConfig;
   }
 
   throw new Error(
     "Missing Urbit config. Either:\n" +
     "  - Set URBIT_URL, URBIT_SHIP, and URBIT_CODE environment variables, or\n" +
-    "  - Configure Tlon channel in Moltbot (~/.clawdbot/moltbot.json)"
+    "  - Configure Tlon channel in OpenClaw (~/.openclaw/openclaw.yaml)"
   );
 }
 


### PR DESCRIPTION
Update all references to reflect the new project name.

## Changes

- **README.md** — links and descriptions
- **SKILL.md** — settings section
- **settings.ts** — CLI help text
- **urbit-client.ts** — config paths (adds `~/.openclaw/` paths, keeps legacy `~/.moltbot/` for backwards compat)

## Note

Settings desk name remains `moltbot` in Urbit settings-store for backwards compatibility with existing data.