### PR TITLE
feat: add rich markdown formatting support

### DIFF
--- a/scripts/dms.ts
+++ b/scripts/dms.ts
@@ -15,33 +15,11 @@
  */
 
 import { getConfig, poke, getCurrentShip, normalizeShip } from "./urbit-client";
+import { markdownToStory, type Story } from "./story";
 
-// Parse content into Story format
-function parseContent(message: string): any[] {
-  const inlines: any[] = [];
-  
-  // Split by ship mentions
-  const parts = message.split(/(~[a-z]+-[a-z]+(?:-[a-z]+)*)/g);
-  
-  for (const part of parts) {
-    if (!part) continue;
-    
-    if (part.match(/^~[a-z]+-[a-z]+(?:-[a-z]+)*$/)) {
-      inlines.push({ ship: part });
-    } else {
-      const lines = part.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i]) {
-          inlines.push(lines[i]);
-        }
-        if (i < lines.length - 1) {
-          inlines.push({ break: null });
-        }
-      }
-    }
-  }
-  
-  return [{ inline: inlines }];
+// Parse content into Story format with rich markdown support
+function parseContent(message: string): Story {
+  return markdownToStory(message);
 }
 
 // Check if the target is a group DM (club)

--- a/scripts/posts.ts
+++ b/scripts/posts.ts
@@ -13,6 +13,7 @@
  */
 
 import { getConfig, poke, getCurrentShip, normalizeShip } from "./urbit-client";
+import { markdownToStory, type Story } from "./story";
 
 // Generate a post ID in @da format from Unix timestamp
 function generatePostId(): string {
@@ -33,35 +34,9 @@ function formatUd(id: string): string {
   return parts.join('.');
 }
 
-// Parse content into Story format (array of verses)
-function parseContent(message: string): any[] {
-  // Simple implementation: treat as inline text with @mentions and linebreaks
-  const inlines: any[] = [];
-  
-  // Split by ship mentions
-  const parts = message.split(/(~[a-z]+-[a-z]+(?:-[a-z]+)*)/g);
-  
-  for (const part of parts) {
-    if (!part) continue;
-    
-    if (part.match(/^~[a-z]+-[a-z]+(?:-[a-z]+)*$/)) {
-      // Ship mention
-      inlines.push({ ship: part });
-    } else {
-      // Handle newlines
-      const lines = part.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i]) {
-          inlines.push(lines[i]);
-        }
-        if (i < lines.length - 1) {
-          inlines.push({ break: null });
-        }
-      }
-    }
-  }
-  
-  return [{ inline: inlines }];
+// Parse content into Story format with rich markdown support
+function parseContent(message: string): Story {
+  return markdownToStory(message);
 }
 
 // Determine channel kind from nest

--- a/scripts/story.ts
+++ b/scripts/story.ts
@@ -1,0 +1,274 @@
+/**
+ * Tlon Story Format - Rich text converter
+ * 
+ * Converts markdown-like text to Tlon's story format.
+ * Based on the openclaw-tlon plugin's story.ts
+ */
+
+// Inline content types
+export type StoryInline =
+  | string
+  | { bold: StoryInline[] }
+  | { italics: StoryInline[] }
+  | { strike: StoryInline[] }
+  | { blockquote: StoryInline[] }
+  | { "inline-code": string }
+  | { code: string }
+  | { ship: string }
+  | { link: { href: string; content: string } }
+  | { break: null }
+  | { tag: string };
+
+// Block content types
+export type StoryBlock =
+  | { header: { tag: "h1" | "h2" | "h3" | "h4" | "h5" | "h6"; content: StoryInline[] } }
+  | { code: { code: string; lang: string } }
+  | { image: { src: string; height: number; width: number; alt: string } }
+  | { rule: null };
+
+// A verse is either a block or inline content
+export type StoryVerse =
+  | { block: StoryBlock }
+  | { inline: StoryInline[] };
+
+// A story is a list of verses
+export type Story = StoryVerse[];
+
+/**
+ * Parse inline markdown formatting (bold, italic, code, links, mentions)
+ */
+function parseInlineMarkdown(text: string): StoryInline[] {
+  const result: StoryInline[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    // Ship mentions: ~sampel-palnet
+    const shipMatch = remaining.match(/^(~[a-z][-a-z0-9]*)/);
+    if (shipMatch) {
+      result.push({ ship: shipMatch[1] });
+      remaining = remaining.slice(shipMatch[0].length);
+      continue;
+    }
+
+    // Bold: **text** or __text__
+    const boldMatch = remaining.match(/^\*\*(.+?)\*\*|^__(.+?)__/);
+    if (boldMatch) {
+      const content = boldMatch[1] || boldMatch[2];
+      result.push({ bold: parseInlineMarkdown(content) });
+      remaining = remaining.slice(boldMatch[0].length);
+      continue;
+    }
+
+    // Italics: *text* or _text_ (but not inside words for _)
+    const italicsMatch = remaining.match(/^\*([^*]+?)\*|^_([^_]+?)_(?![a-zA-Z0-9])/);
+    if (italicsMatch) {
+      const content = italicsMatch[1] || italicsMatch[2];
+      result.push({ italics: parseInlineMarkdown(content) });
+      remaining = remaining.slice(italicsMatch[0].length);
+      continue;
+    }
+
+    // Strikethrough: ~~text~~
+    const strikeMatch = remaining.match(/^~~(.+?)~~/);
+    if (strikeMatch) {
+      result.push({ strike: parseInlineMarkdown(strikeMatch[1]) });
+      remaining = remaining.slice(strikeMatch[0].length);
+      continue;
+    }
+
+    // Inline code: `code`
+    const codeMatch = remaining.match(/^`([^`]+)`/);
+    if (codeMatch) {
+      result.push({ "inline-code": codeMatch[1] });
+      remaining = remaining.slice(codeMatch[0].length);
+      continue;
+    }
+
+    // Links: [text](url)
+    const linkMatch = remaining.match(/^\[([^\]]+)\]\(([^)]+)\)/);
+    if (linkMatch) {
+      result.push({ link: { href: linkMatch[2], content: linkMatch[1] } });
+      remaining = remaining.slice(linkMatch[0].length);
+      continue;
+    }
+
+    // Plain URL detection
+    const urlMatch = remaining.match(/^(https?:\/\/[^\s<>"\]]+)/);
+    if (urlMatch) {
+      result.push({ link: { href: urlMatch[1], content: urlMatch[1] } });
+      remaining = remaining.slice(urlMatch[0].length);
+      continue;
+    }
+
+    // Plain text: consume until next special character
+    const plainMatch = remaining.match(/^[^*_`~\[#~\n]+/);
+    if (plainMatch) {
+      result.push(plainMatch[0]);
+      remaining = remaining.slice(plainMatch[0].length);
+      continue;
+    }
+
+    // Single special char that didn't match a pattern
+    result.push(remaining[0]);
+    remaining = remaining.slice(1);
+  }
+
+  // Merge adjacent strings
+  return mergeAdjacentStrings(result);
+}
+
+/**
+ * Merge adjacent string elements in an inline array
+ */
+function mergeAdjacentStrings(inlines: StoryInline[]): StoryInline[] {
+  const result: StoryInline[] = [];
+  for (const item of inlines) {
+    if (typeof item === "string" && typeof result[result.length - 1] === "string") {
+      result[result.length - 1] = (result[result.length - 1] as string) + item;
+    } else {
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+/**
+ * Convert markdown text to Tlon story format
+ */
+export function markdownToStory(markdown: string): Story {
+  const story: Story = [];
+  const lines = markdown.split("\n");
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Code block: ```lang\ncode\n```
+    if (line.startsWith("```")) {
+      const lang = line.slice(3).trim() || "plaintext";
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      story.push({
+        block: {
+          code: {
+            code: codeLines.join("\n"),
+            lang,
+          },
+        },
+      });
+      i++; // skip closing ```
+      continue;
+    }
+
+    // Headers: # H1, ## H2, etc.
+    const headerMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headerMatch) {
+      const level = headerMatch[1].length as 1 | 2 | 3 | 4 | 5 | 6;
+      const tag = `h${level}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+      story.push({
+        block: {
+          header: {
+            tag,
+            content: parseInlineMarkdown(headerMatch[2]),
+          },
+        },
+      });
+      i++;
+      continue;
+    }
+
+    // Horizontal rule: --- or ***
+    if (/^(-{3,}|\*{3,})$/.test(line.trim())) {
+      story.push({ block: { rule: null } });
+      i++;
+      continue;
+    }
+
+    // Blockquote: > text
+    if (line.startsWith("> ")) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && lines[i].startsWith("> ")) {
+        quoteLines.push(lines[i].slice(2));
+        i++;
+      }
+      const quoteText = quoteLines.join("\n");
+      story.push({
+        inline: [{ blockquote: parseInlineMarkdown(quoteText) }],
+      });
+      continue;
+    }
+
+    // Empty line - skip
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // Regular paragraph - collect consecutive non-empty lines
+    const paragraphLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !lines[i].startsWith("#") &&
+      !lines[i].startsWith("```") &&
+      !lines[i].startsWith("> ") &&
+      !/^(-{3,}|\*{3,})$/.test(lines[i].trim())
+    ) {
+      paragraphLines.push(lines[i]);
+      i++;
+    }
+
+    if (paragraphLines.length > 0) {
+      const paragraphText = paragraphLines.join("\n");
+      const inlines = parseInlineMarkdown(paragraphText);
+      
+      // Replace \n in strings with break elements
+      const withBreaks: StoryInline[] = [];
+      for (const inline of inlines) {
+        if (typeof inline === "string" && inline.includes("\n")) {
+          const parts = inline.split("\n");
+          for (let j = 0; j < parts.length; j++) {
+            if (parts[j]) withBreaks.push(parts[j]);
+            if (j < parts.length - 1) withBreaks.push({ break: null });
+          }
+        } else {
+          withBreaks.push(inline);
+        }
+      }
+      
+      if (withBreaks.length > 0) {
+        story.push({ inline: withBreaks });
+      }
+    }
+  }
+
+  return story;
+}
+
+/**
+ * Convert plain text to simple story (just handles ship mentions and breaks)
+ */
+export function textToStory(text: string): Story {
+  const inlines: StoryInline[] = [];
+  const parts = text.split(/(~[a-z]+-[a-z]+(?:-[a-z]+)*)/g);
+
+  for (const part of parts) {
+    if (!part) continue;
+
+    if (part.match(/^~[a-z]+-[a-z]+(?:-[a-z]+)*$/)) {
+      inlines.push({ ship: part });
+    } else {
+      const lines = part.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i]) inlines.push(lines[i]);
+        if (i < lines.length - 1) inlines.push({ break: null });
+      }
+    }
+  }
+
+  return [{ inline: inlines }];
+}


### PR DESCRIPTION
## Summary

Adds rich markdown formatting support to posts and DMs, matching the plugin's capabilities.

## Changes

- **New:** `scripts/story.ts` - Markdown to Tlon Story converter
- **Updated:** `scripts/posts.ts` - Uses rich formatting for channel posts
- **Updated:** `scripts/dms.ts` - Uses rich formatting for direct messages

## Supported Formatting

| Syntax | Result |
|--------|--------|
| `**bold**` | **bold** |
| `*italic*` | *italic* |
| `~~strike~~` | ~~strikethrough~~ |
| `\`code\`` | inline code |
| `\`\`\`lang...\`\`\`` | code blocks |
| `[text](url)` | links |
| `https://...` | auto-linked URLs |
| `# Header` | h1-h6 headers |
| `> quote` | blockquotes |
| `---` | horizontal rules |
| `~ship` | ship mentions |

## Testing

```bash
# Test rich formatting in a post
tlon-run posts send chat/~host/channel "**Bold** and *italic* with \`code\`"

# Test in DM
tlon-run dms send ~ship "Check out [this link](https://example.com)"
```