### PR TITLE
Reenable skill for dms and posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Options: `--limit N`, `--resolve-cites` (resolve quoted messages)
 
 ### Posts (Channel Management)
 
-Manage channel posts. Sending and replying is handled by the Tlon channel plugin.
+Post to channels (chat, diary, heap).
 
 ```bash
 tlon-run posts react chat/~host/channel 170.141.184.507... "👍"
@@ -201,7 +201,7 @@ Post IDs are @ud numbers with dots (e.g. `170.141.184.507.802.259...`). Get them
 
 ### DMs (Direct Messages)
 
-Manage direct messages. 1:1 DM send/reply is handled by the Tlon channel plugin — use `tlon-run` for group DMs (clubs) and management ops.
+Manage direct messages. 1:1 DM send/reply are also handled by the Tlon channel plugin — use `tlon-run` for group DMs (clubs) and management ops.
 
 ```bash
 # Group DMs (clubs) only
@@ -443,13 +443,17 @@ npx ts-node scripts/messages.ts channel chat/~host/slug --limit 20 # -> tlon-run
 npx ts-node scripts/messages.ts history chat/~host/slug --limit 20 # -> tlon-run messages history
 npx ts-node scripts/messages.ts search "query" --channel chat/~host/slug
 
-# Posts (management — send/reply handled by channel plugin)
+# Posts (channel posting)
+npx ts-node scripts/posts.ts send chat/~host/slug "message"       # Post to channel              -> tlon-run posts send
+npx ts-node scripts/posts.ts reply chat/~host/slug 170.141.184.507... "reply" # Reply to post    -> tlon-run posts reply
 npx ts-node scripts/posts.ts react chat/~host/slug 170.141... 👍      # -> tlon-run posts react
 npx ts-node scripts/posts.ts unreact chat/~host/slug 170.141...       # -> tlon-run posts unreact
 npx ts-node scripts/posts.ts delete chat/~host/slug 170.141...        # -> tlon-run posts delete
 
-# Direct Messages (management — 1:1 send/reply handled by channel plugin)
-npx ts-node scripts/dms.ts send 0v4.club-id "hello"            # -> tlon-run dms send (group DM)
+# Direct Messages (send/reply/react/delete + invites)
+npx ts-node scripts/dms.ts send ~sampel "hello"                   # Send a DM                   -> tlon-run dms send
+npx ts-node scripts/dms.ts send 0v4.club-id "hello"               # Send to group DM (club)      -> tlon-run dms send
+npx ts-node scripts/dms.ts reply ~sampel ~author/170.141... "reply"  # Reply in DM thread         -> tlon-run dms reply
 npx ts-node scripts/dms.ts react ~sampel ~author/170.141... 👍        # -> tlon-run dms react
 npx ts-node scripts/dms.ts unreact ~sampel ~author/170.141...         # -> tlon-run dms unreact
 npx ts-node scripts/dms.ts delete ~sampel ~author/170.141...          # -> tlon-run dms delete

--- a/SKILL.md
+++ b/SKILL.md
@@ -114,7 +114,7 @@ Options: `--limit N`, `--resolve-cites` (resolve quoted messages)
 
 ### DMs
 
-Manage direct messages. Sending and replying to 1:1 DMs is handled by the Tlon channel plugin — use `tlon-run` only for group DM (club) messaging and DM management operations.
+Manage direct messages. Sending and replying to 1:1 DMs is handled by the Tlon channel plugin — use `tlon-run` only for group DM (club) messaging and DM management operations if possible.
 
 ```bash
 # Group DMs (clubs) only — 1:1 DM send/reply uses the channel plugin

--- a/bin/tlon-run
+++ b/bin/tlon-run
@@ -31,8 +31,8 @@ Commands:
   groups add-channel ~host/slug "Name" [opts]  - Add channel to group
   messages {dm|channel|history} [--limit N]    - Read messages
   messages search "query" --channel <nest>     - Search messages
-  dms send <club-id> "msg"                      - Send to group DM (clubs only)
-  dms reply <club-id> <id> "msg"               - Reply in group DM (clubs only)
+  dms {send|reply|react|unreact|delete}        - DM operations
+  dms reply <planet|club-id> <id> "msg"        - Reply in DM
   dms {react|unreact|delete}                   - DM management
   dms {accept|decline}                         - DM invites
   posts {react|unreact|delete}                 - Channel post management
@@ -552,26 +552,18 @@ case "$cmd" in
       send)
         target="${1:-}"
         msg="${2:-}"
-        [ -n "$target" ] || { echo "error: missing target"; echo "usage: tlon-run dms send <club-id> \"message\""; exit 2; }
+        [ -n "$target" ] || { echo "error: missing target"; echo "usage: tlon-run dms send ~ship|<club-id> \"message\""; exit 2; }
         [ -n "$msg" ] || { echo "error: missing message"; exit 2; }
-        # 1:1 DM send is handled by the Tlon channel plugin; only club (group DM) send goes through here
-        case "$target" in
-          0v*) exec node "$DIST_DIR/dms.js" send "$target" "$msg" ;;
-          *) echo "error: 1:1 DM send is handled by the Tlon channel plugin."; echo "Use the channel message tool with channel=tlon instead."; exit 2 ;;
-        esac
+        exec node "$DIST_DIR/dms.js" send "$target" "$msg"
         ;;
       reply)
         target="${1:-}"
         post_id="${2:-}"
         msg="${3:-}"
-        [ -n "$target" ] || { echo "error: missing target"; echo "usage: tlon-run dms reply <club-id> <post-id> \"message\""; exit 2; }
+        [ -n "$target" ] || { echo "error: missing target"; echo "usage: tlon-run dms reply ~ship <post-id> \"message\""; exit 2; }
         [ -n "$post_id" ] || { echo "error: missing post id"; exit 2; }
         [ -n "$msg" ] || { echo "error: missing message"; exit 2; }
-        # 1:1 DM reply is handled by the Tlon channel plugin; only club (group DM) reply goes through here
-        case "$target" in
-          0v*) exec node "$DIST_DIR/dms.js" reply "$target" "$post_id" "$msg" ;;
-          *) echo "error: 1:1 DM reply is handled by the Tlon channel plugin."; echo "Use the channel message tool with channel=tlon and replyTo instead."; exit 2 ;;
-        esac
+        exec node "$DIST_DIR/dms.js" reply "$target" "$post_id" "$msg"
         ;;
       react)
         target="${1:-}"
@@ -621,26 +613,22 @@ case "$cmd" in
     shift || true
     case "$sub" in
       send)
-        # Channel post send is handled by the Tlon channel plugin
-        echo "error: Channel post send is handled by the Tlon channel plugin."
-        echo "Use the channel message tool with channel=tlon instead."
-        exit 2
+        chan="${1:-}"
+        msg="${2:-}"
+        [ -n "$chan" ] || { echo "error: missing channel"; echo "usage: tlon-run posts send chat/~host/slug \"message\""; exit 2; }
+        [ -n "$msg" ] || { echo "error: missing message"; exit 2; }
+        validate_channel "$chan"
+        exec node "$DIST_DIR/posts.js" send "$chan" "$msg"
         ;;
       reply)
-        # Channel post reply is handled by the Tlon channel plugin
-        echo "error: Channel post reply is handled by the Tlon channel plugin."
-        echo "Use the channel message tool with channel=tlon and replyTo instead."
-        exit 2
-        ;;
-      react)
         chan="${1:-}"
         post_id="${2:-}"
-        emoji="${3:-}"
-        [ -n "$chan" ] || { echo "error: missing channel"; echo "usage: tlon-run posts react chat/~host/slug <post-id> <emoji>"; exit 2; }
+        msg="${3:-}"
+        [ -n "$chan" ] || { echo "error: missing channel"; echo "usage: tlon-run posts reply chat/~host/slug <post-id> \"message\""; exit 2; }
         [ -n "$post_id" ] || { echo "error: missing post id"; exit 2; }
-        [ -n "$emoji" ] || { echo "error: missing emoji"; exit 2; }
+        [ -n "$msg" ] || { echo "error: missing message"; exit 2; }
         validate_channel "$chan"
-        exec node "$DIST_DIR/posts.js" react "$chan" "$post_id" "$emoji"
+        exec node "$DIST_DIR/posts.js" reply "$chan" "$post_id" "$msg"
         ;;
       unreact)
         chan="${1:-}"

--- a/scripts/dms.ts
+++ b/scripts/dms.ts
@@ -1,27 +1,48 @@
 #!/usr/bin/env npx ts-node
 /**
- * Direct Message management for Tlon
- *
- * Note: 1:1 DM send/reply is handled by the openclaw-tlon channel plugin.
- * This script handles club (group DM) messaging and DM management ops only.
+ * Direct Message operations for Tlon
  *
  * Usage:
- *   npx ts-node scripts/dms.ts send <club-id> <message>        (group DMs only)
- *   npx ts-node scripts/dms.ts reply <club-id> <post-id> <msg> (group DMs only)
+ *   npx ts-node scripts/dms.ts send <ship> <message>
+ *   npx ts-node scripts/dms.ts reply <ship> <post-id> <message>
  *   npx ts-node scripts/dms.ts react <ship> <post-id> <emoji>
  *   npx ts-node scripts/dms.ts unreact <ship> <post-id>
  *   npx ts-node scripts/dms.ts delete <ship> <post-id>
  *   npx ts-node scripts/dms.ts accept <ship>
  *   npx ts-node scripts/dms.ts decline <ship>
+ *
+ * For group DMs, use the club ID (0v format) instead of ship
  */
 
 import { getConfig, poke, getCurrentShip, normalizeShip } from "./urbit-client";
 import { scot, da } from "@urbit/aura";
-import { markdownToStory, type Story } from "./story";
 
-// Parse content into Story format with rich markdown support
-function parseContent(message: string): Story {
-  return markdownToStory(message);
+// Parse content into Story format
+function parseContent(message: string): any[] {
+  const inlines: any[] = [];
+  
+  // Split by ship mentions
+  const parts = message.split(/(~[a-z]+-[a-z]+(?:-[a-z]+)*)/g);
+  
+  for (const part of parts) {
+    if (!part) continue;
+    
+    if (part.match(/^~[a-z]+-[a-z]+(?:-[a-z]+)*$/)) {
+      inlines.push({ ship: part });
+    } else {
+      const lines = part.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i]) {
+          inlines.push(lines[i]);
+        }
+        if (i < lines.length - 1) {
+          inlines.push({ break: null });
+        }
+      }
+    }
+  }
+  
+  return [{ inline: inlines }];
 }
 
 // Check if the target is a group DM (club)
@@ -29,8 +50,42 @@ function isClub(whom: string): boolean {
   return whom.startsWith("0v");
 }
 
-// sendDM: Handled by the openclaw-tlon channel plugin (sendText).
-// Use the Tlon channel's message tool instead of tlon-run for 1:1 DMs.
+// Send a DM to a ship
+async function sendDM(
+  ship: string,
+  message: string
+): Promise<{ success: boolean; postId?: string; error?: string }> {
+  const normalizedShip = normalizeShip(ship);
+  const author = getCurrentShip();
+  const sent = Date.now();
+  const content = parseContent(message);
+  const idUd = scot("ud", da.fromUnix(sent));
+  const id = `${author}/${idUd}`;
+
+  try {
+    await poke({
+      app: "chat",
+      mark: "chat-dm-action",
+      json: {
+        ship: normalizedShip,
+        diff: {
+          id,
+          delta: {
+            add: {
+              memo: { content, author, sent },
+              kind: null,
+              time: null,
+            },
+          },
+        },
+      },
+    });
+
+    return { success: true, postId: id };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
 
 // Send a message to a group DM (club)
 async function sendClubMessage(
@@ -73,8 +128,48 @@ async function sendClubMessage(
   }
 }
 
-// replyToDM: Handled by the openclaw-tlon channel plugin (sendText with replyToId).
-// Use the Tlon channel's message tool instead of tlon-run for 1:1 DM replies.
+// Reply to a DM
+async function replyToDM(
+  ship: string,
+  postId: string,
+  message: string
+): Promise<{ success: boolean; replyId?: string; error?: string }> {
+  const normalizedShip = normalizeShip(ship);
+  const author = getCurrentShip();
+  const sent = Date.now();
+  const content = parseContent(message);
+  const idUd = scot("ud", da.fromUnix(sent));
+  const replyId = `${author}/${idUd}`;
+
+  try {
+    await poke({
+      app: "chat",
+      mark: "chat-dm-action",
+      json: {
+        ship: normalizedShip,
+        diff: {
+          id: postId,
+          delta: {
+            reply: {
+              id: replyId,
+              meta: null,
+              delta: {
+                add: {
+                  memo: { content, author, sent },
+                  time: null,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return { success: true, replyId };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
 
 // Reply in a club (group DM)
 async function replyToClub(
@@ -266,15 +361,14 @@ async function main() {
         const whom = args[1];
         const message = args.slice(2).join(" ");
         if (!whom || !message) {
-          console.error("Usage: dms.ts send <club-id> <message>");
+          console.error("Usage: dms.ts send <ship|club-id> <message>");
+          console.error("Example: dms.ts send ~sampel-palnet Hello!");
           process.exit(1);
         }
         if (isClub(whom)) {
           result = await sendClubMessage(whom, message);
         } else {
-          console.error("error: 1:1 DM send is handled by the Tlon channel plugin.");
-          console.error("Use the channel message tool with channel=tlon instead.");
-          process.exit(1);
+          result = await sendDM(whom, message);
         }
         break;
       }
@@ -284,15 +378,13 @@ async function main() {
         const postId = args[2];
         const message = args.slice(3).join(" ");
         if (!whom || !postId || !message) {
-          console.error("Usage: dms.ts reply <club-id> <post-id> <message>");
+          console.error("Usage: dms.ts reply <ship|club-id> <post-id> <message>");
           process.exit(1);
         }
         if (isClub(whom)) {
           result = await replyToClub(whom, postId, message);
         } else {
-          console.error("error: 1:1 DM reply is handled by the Tlon channel plugin.");
-          console.error("Use the channel message tool with channel=tlon and replyTo instead.");
-          process.exit(1);
+          result = await replyToDM(whom, postId, message);
         }
         break;
       }
@@ -357,23 +449,21 @@ async function main() {
         console.error(`
 Usage: dms.ts <command> [args]
 
-Note: 1:1 DM send/reply is handled by the Tlon channel plugin.
-Use tlon-run only for club (group DM) send/reply and DM management ops.
-
 Commands:
-  send <club-id> <message>                   Send to group DM (club only)
-  reply <club-id> <post-id> <message>        Reply in group DM (club only)
+  send <ship|club-id> <message>              Send a DM
+  reply <ship|club-id> <post-id> <message>   Reply to a DM
   react <ship> <post-id> <emoji>             React to a DM with an emoji
   unreact <ship> <post-id>                   Remove your reaction from a DM
   delete <ship> <post-id>                    Delete a DM
   accept <ship>                              Accept a DM invite
   decline <ship>                             Decline a DM invite
 
+Ship format: ~sampel-palnet (with or without ~)
 Club ID format: 0v... (for group DMs)
-Post ID format: ~author/170.141.184.507...
+Post ID format: ~author/170.141.184.507... (returned by send/reply)
 
 Examples:
-  dms.ts send 0v4.club-id "Hello group"
+  dms.ts send ~sampel-palnet "Hey, how's it going?"
   dms.ts react ~sampel-palnet ~zod/170.141.184.507... ❤️
   dms.ts accept ~sampel-palnet
 `);

--- a/scripts/posts.ts
+++ b/scripts/posts.ts
@@ -1,14 +1,12 @@
 #!/usr/bin/env npx ts-node
 /**
- * Channel post management for Tlon
- *
- * Note: Sending and replying to channel posts is handled by the openclaw-tlon
- * channel plugin. This script handles reactions, edits, and deletes only.
+ * Post to Tlon channels (chat, diary, heap)
  *
  * Usage:
+ *   npx ts-node scripts/posts.ts send <channel> <message>
+ *   npx ts-node scripts/posts.ts reply <channel> <post-id> <message>
  *   npx ts-node scripts/posts.ts react <channel> <post-id> <emoji>
  *   npx ts-node scripts/posts.ts unreact <channel> <post-id>
- *   npx ts-node scripts/posts.ts edit <channel> <post-id> <message>
  *   npx ts-node scripts/posts.ts delete <channel> <post-id>
  *
  * Channel format: chat/~host/channel-name, diary/~host/channel-name, heap/~host/channel-name
@@ -16,13 +14,6 @@
 
 import { getConfig, poke, getCurrentShip, normalizeShip } from "./urbit-client";
 import { scot, da } from "@urbit/aura";
-import { markdownToStory, type Story } from "./story";
-
-// Strip optional ~ship/ prefix from a post ID, returning just the numeric part
-function extractNumericId(id: string): string {
-  const slash = id.indexOf('/');
-  return slash >= 0 ? id.slice(slash + 1) : id;
-}
 
 // Format a post ID as @ud (with dots every 3 digits)
 // This is required for reactions to work properly
@@ -37,9 +28,35 @@ function formatUd(id: string): string {
   return parts.join('.');
 }
 
-// Parse content into Story format with rich markdown support
-function parseContent(message: string): Story {
-  return markdownToStory(message);
+// Parse content into Story format (array of verses)
+function parseContent(message: string): any[] {
+  // Simple implementation: treat as inline text with @mentions and linebreaks
+  const inlines: any[] = [];
+  
+  // Split by ship mentions
+  const parts = message.split(/(~[a-z]+-[a-z]+(?:-[a-z]+)*)/g);
+  
+  for (const part of parts) {
+    if (!part) continue;
+    
+    if (part.match(/^~[a-z]+-[a-z]+(?:-[a-z]+)*$/)) {
+      // Ship mention
+      inlines.push({ ship: part });
+    } else {
+      // Handle newlines
+      const lines = part.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i]) {
+          inlines.push(lines[i]);
+        }
+        if (i < lines.length - 1) {
+          inlines.push({ break: null });
+        }
+      }
+    }
+  }
+  
+  return [{ inline: inlines }];
 }
 
 // Determine channel kind from nest
@@ -53,11 +70,90 @@ function getChannelKind(nest: string): string {
   }
 }
 
-// sendPost: Handled by the openclaw-tlon channel plugin (sendText).
-// Use the Tlon channel's message tool instead of tlon-run for posting to channels.
+// Send a post to a channel
+async function sendPost(nest: string, message: string): Promise<{ success: boolean; postId?: string; error?: string }> {
+  const config = getConfig();
+  const author = getCurrentShip();
+  const sent = Date.now();
+  const content = parseContent(message);
+  const kind = getChannelKind(nest);
 
-// replyToPost: Handled by the openclaw-tlon channel plugin (sendText with replyToId).
-// Use the Tlon channel's message tool with replyTo instead of tlon-run for replies.
+  const essay = {
+    content,
+    author,
+    sent,
+    kind,
+    blob: null,
+    meta: null,
+  };
+
+  try {
+    await poke({
+      app: "channels",
+      mark: "channel-action-1",
+      json: {
+        channel: {
+          nest,
+          action: {
+            post: {
+              add: essay,
+            },
+          },
+        },
+      },
+    });
+
+    const idUd = scot("ud", da.fromUnix(sent));
+    return { success: true, postId: `${author}/${idUd}` };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Reply to a post in a channel
+async function replyToPost(
+  nest: string,
+  postId: string,
+  message: string
+): Promise<{ success: boolean; replyId?: string; error?: string }> {
+  const config = getConfig();
+  const author = getCurrentShip();
+  const sent = Date.now();
+  const content = parseContent(message);
+
+  const memo = {
+    content,
+    author,
+    sent,
+  };
+
+  try {
+    await poke({
+      app: "channels",
+      mark: "channel-action-1",
+      json: {
+        channel: {
+          nest,
+          action: {
+            post: {
+              reply: {
+                id: postId,
+                action: {
+                  add: memo,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const idUd = scot("ud", da.fromUnix(sent));
+    return { success: true, replyId: `${author}/${idUd}` };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
 
 // React to a post
 async function reactToPost(
@@ -66,7 +162,7 @@ async function reactToPost(
   react: string
 ): Promise<{ success: boolean; error?: string }> {
   const ship = getCurrentShip();
-  const formattedId = formatUd(extractNumericId(postId));
+  const formattedId = formatUd(postId);
 
   try {
     await poke({
@@ -100,7 +196,7 @@ async function unreactToPost(
   postId: string
 ): Promise<{ success: boolean; error?: string }> {
   const ship = getCurrentShip();
-  const formattedId = formatUd(extractNumericId(postId));
+  const formattedId = formatUd(postId);
 
   try {
     await poke({
@@ -169,7 +265,7 @@ async function editPost(
           action: {
             post: {
               edit: {
-                id: formatUd(extractNumericId(postId)),
+                id: postId,
                 essay,
               },
             },
@@ -200,7 +296,7 @@ async function deletePost(
           nest,
           action: {
             post: {
-              del: formatUd(extractNumericId(postId)),
+              del: postId,
             },
           },
         },
@@ -223,16 +319,27 @@ async function main() {
 
     switch (command) {
       case "send": {
-        console.error("error: Channel post send is handled by the Tlon channel plugin.");
-        console.error("Use the channel message tool with channel=tlon instead.");
-        process.exit(1);
+        const nest = args[1];
+        const message = args.slice(2).join(" ");
+        if (!nest || !message) {
+          console.error("Usage: posts.ts send <channel> <message>");
+          console.error("Example: posts.ts send chat/~sampel/general Hello world!");
+          process.exit(1);
+        }
+        result = await sendPost(nest, message);
         break;
       }
 
       case "reply": {
-        console.error("error: Channel post reply is handled by the Tlon channel plugin.");
-        console.error("Use the channel message tool with channel=tlon and replyTo instead.");
-        process.exit(1);
+        const nest = args[1];
+        const postId = args[2];
+        const message = args.slice(3).join(" ");
+        if (!nest || !postId || !message) {
+          console.error("Usage: posts.ts reply <channel> <post-id> <message>");
+          console.error("Example: posts.ts reply chat/~sampel/general 170.141.184.507... Nice post!");
+          process.exit(1);
+        }
+        result = await replyToPost(nest, postId, message);
         break;
       }
 
@@ -304,22 +411,21 @@ async function main() {
         console.error(`
 Usage: posts.ts <command> [args]
 
-Note: Sending and replying to posts is handled by the Tlon channel plugin.
-Use tlon-run only for reactions, edits, and deletes.
-
 Commands:
+  send <channel> <message>              Post a message to a channel
+  reply <channel> <post-id> <message>   Reply to a post
   react <channel> <post-id> <emoji>     React to a post with an emoji
   unreact <channel> <post-id>           Remove your reaction from a post
   edit <channel> <post-id> <message>    Edit a post [--title <t> for notebooks]
   delete <channel> <post-id>            Delete a post
 
 Channel format: chat/~host/channel-name, diary/~host/name, heap/~host/name
-Post IDs are @ud format with dots (e.g., 170.141.184.507...).
-Use 'tlon-run messages channel <nest> --limit N' to see post IDs.
+Post IDs for delete must be @da format (e.g., 170.141.184.507....). 
+Use 'messages.ts channel <nest> --limit N' to see actual post IDs.
 
 Examples:
+  posts.ts send chat/~sampel/general "Hello everyone!"
   posts.ts react chat/~sampel/general 170.141.184.507... 👍
-  posts.ts delete chat/~sampel/general 170.141.184.507...
 `);
         process.exit(1);
     }


### PR DESCRIPTION
We have been having a bad time with the bots being unable to discern how to initialize messages in separate channels from where they are prompted via the plugin. They were previously able to do this with the tool, but now we just get blackholed or they tell us they can't. In the absence of a combined skill/plugin, I am proposing reenabling these utilities at least until the former is ready.