### PR TITLE
fix: cross-compile darwin-x64 from ARM64 runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-14        # ARM64
+          - os: macos-14
             target: darwin-arm64
-          - os: macos-12        # x64 (Intel)
+          - os: macos-14        # Cross-compile x64 from ARM64
             target: darwin-x64
           - os: ubuntu-latest
             target: linux-x64
@@ -40,7 +40,7 @@ jobs:
         run: npm install
 
       - name: Build binary
-        run: node scripts/build-all.js
+        run: node scripts/build-all.js --target=${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -3,7 +3,11 @@
 /**
  * Build script for all platforms.
  * Run locally to build for current platform only.
- * CI runs this on each platform's runner.
+ * CI runs this on each platform's runner, or cross-compiles with --target.
+ *
+ * Usage:
+ *   node scripts/build-all.js                    # Build for current platform
+ *   node scripts/build-all.js --target linux-x64 # Cross-compile for linux-x64
  */
 
 import { execSync } from "node:child_process";
@@ -14,26 +18,47 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..");
 
-const platform = process.platform;
-const arch = process.arch;
-const target = `${platform}-${arch}`;
+// Parse --target argument
+const targetArg = process.argv.find((arg) => arg.startsWith("--target="));
+const target = targetArg
+  ? targetArg.split("=")[1]
+  : `${process.platform}-${process.arch}`;
 
-console.log(`Building for ${target}...`);
+// Map our target names to bun's target names
+const bunTargets = {
+  "darwin-arm64": "bun-darwin-arm64",
+  "darwin-x64": "bun-darwin-x64",
+  "linux-x64": "bun-linux-x64",
+  "linux-arm64": "bun-linux-arm64",
+};
+
+const bunTarget = bunTargets[target];
+if (!bunTarget) {
+  console.error(`Unknown target: ${target}`);
+  console.error(`Supported targets: ${Object.keys(bunTargets).join(", ")}`);
+  process.exit(1);
+}
+
+console.log(`Building for ${target} (bun target: ${bunTarget})...`);
 
 // Build the binary
 const distDir = join(rootDir, "dist");
 mkdirSync(distDir, { recursive: true });
 
-const binaryName = platform === "win32" ? "tlon.exe" : "tlon";
+const binaryName = target.startsWith("win") ? "tlon.exe" : "tlon";
 const binaryPath = join(distDir, binaryName);
 
-execSync(`bun build scripts/main.ts --compile --outfile ${binaryPath}`, {
-  cwd: rootDir,
-  stdio: "inherit",
-});
+execSync(
+  `bun build scripts/main.ts --compile --target=${bunTarget} --outfile ${binaryPath}`,
+  {
+    cwd: rootDir,
+    stdio: "inherit",
+  }
+);
 
 // Copy to the appropriate npm package directory
 const npmDir = join(rootDir, "npm", target);
+mkdirSync(npmDir, { recursive: true });
 cpSync(binaryPath, join(npmDir, binaryName));
 
 console.log(`Built and copied to npm/${target}/${binaryName}`);


### PR DESCRIPTION
- Update build-all.js to support --target flag for cross-compilation
- Use macos-14 to cross-compile darwin-x64 (macos-12 deprecated)
- Bun supports cross-compilation via --target=bun-darwin-x64