### PR TITLE
Fix CI publish: add platform package.json files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Copy binaries to npm packages
         run: |
           for target in darwin-arm64 darwin-x64 linux-x64; do
+            mkdir -p npm/$target
             cp artifacts/binary-$target/tlon npm/$target/
             chmod +x npm/$target/tlon
           done

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 *.log
 .DS_Store
 dist
-npm
+# Ignore binaries, keep package.json
+npm/*/tlon
 bin/tlon

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tloncorp/tlon-skill-darwin-arm64",
+  "version": "0.1.0",
+  "description": "Tlon skill binary for macOS ARM64",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "bin": {
+    "tlon": "tlon"
+  },
+  "files": ["tlon"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/tlon-skill"
+  },
+  "license": "MIT"
+}

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tloncorp/tlon-skill-darwin-x64",
+  "version": "0.1.0",
+  "description": "Tlon skill binary for macOS x64",
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "bin": {
+    "tlon": "tlon"
+  },
+  "files": ["tlon"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/tlon-skill"
+  },
+  "license": "MIT"
+}

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tloncorp/tlon-skill-linux-x64",
+  "version": "0.1.0",
+  "description": "Tlon skill binary for Linux x64",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "bin": {
+    "tlon": "tlon"
+  },
+  "files": ["tlon"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/tlon-skill"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
Fixes the publish step failing with 'No such file or directory':

- Add package.json for darwin-arm64, darwin-x64, linux-x64
- Update .gitignore to track package.json but ignore binaries
- Add mkdir -p in publish step for safety