### PR TITLE
Fix npm install: move build deps to devDependencies

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tlon skill binary for macOS ARM64",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tlon skill binary for macOS x64",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-linux-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tlon skill binary for Linux x64",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tlon/Urbit skill for OpenClaw agents",
   "type": "module",
   "bin": {
@@ -17,15 +17,13 @@
     "test": "bun test"
   },
   "optionalDependencies": {
-    "@tloncorp/tlon-skill-darwin-arm64": "0.1.0",
-    "@tloncorp/tlon-skill-darwin-x64": "0.1.0",
-    "@tloncorp/tlon-skill-linux-x64": "0.1.0"
-  },
-  "dependencies": {
-    "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#main",
-    "@urbit/aura": "^3.0.0"
+    "@tloncorp/tlon-skill-darwin-arm64": "0.1.1",
+    "@tloncorp/tlon-skill-darwin-x64": "0.1.1",
+    "@tloncorp/tlon-skill-linux-x64": "0.1.1"
   },
   "devDependencies": {
+    "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#main",
+    "@urbit/aura": "^3.0.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.9.3"
   },


### PR DESCRIPTION
Users were getting build errors because @tloncorp/api requires vite to build.

- Move @tloncorp/api and @urbit/aura to devDependencies
- These are only needed for building, not running the pre-built binary
- Bump to 0.1.1