### PR TITLE
Fix shim: binary is 'tlon' not 'tlon-run'

### DIFF
--- a/bin/tlon-run.js
+++ b/bin/tlon-run.js
@@ -37,7 +37,7 @@ function getBinaryPath() {
   try {
     // Try to resolve the platform-specific package
     const packagePath = require.resolve(`${packageName}/package.json`);
-    const binaryPath = join(dirname(packagePath), "tlon-run");
+    const binaryPath = join(dirname(packagePath), "tlon");
     
     if (!existsSync(binaryPath)) {
       throw new Error(`Binary not found at ${binaryPath}`);

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-arm64",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Tlon skill binary for macOS ARM64",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-x64",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Tlon skill binary for macOS x64",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-linux-x64",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Tlon skill binary for Linux x64",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Tlon/Urbit skill for OpenClaw agents",
   "type": "module",
   "bin": {
@@ -17,9 +17,9 @@
     "test": "bun test"
   },
   "optionalDependencies": {
-    "@tloncorp/tlon-skill-darwin-arm64": "0.1.1",
-    "@tloncorp/tlon-skill-darwin-x64": "0.1.1",
-    "@tloncorp/tlon-skill-linux-x64": "0.1.1"
+    "@tloncorp/tlon-skill-darwin-arm64": "0.1.2",
+    "@tloncorp/tlon-skill-darwin-x64": "0.1.2",
+    "@tloncorp/tlon-skill-linux-x64": "0.1.2"
   },
   "devDependencies": {
     "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#main",


### PR DESCRIPTION
The shim was looking for 'tlon-run' but the binary is named 'tlon'.

Bump to 0.1.2