### PR TITLE
feat: add linux-arm64 build for Docker on Apple Silicon

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
             target: darwin-x64
           - os: ubuntu-latest
             target: linux-x64
+          - os: ubuntu-latest   # Cross-compile arm64 from x64
+            target: linux-arm64
 
     runs-on: ${{ matrix.os }}
 
@@ -71,7 +73,7 @@ jobs:
 
       - name: Copy binaries to npm packages
         run: |
-          for target in darwin-arm64 darwin-x64 linux-x64; do
+          for target in darwin-arm64 darwin-x64 linux-x64 linux-arm64; do
             mkdir -p npm/$target
             cp artifacts/binary-$target/tlon npm/$target/
             chmod +x npm/$target/tlon
@@ -89,7 +91,7 @@ jobs:
           else
             echo "Using NPM_TOKEN"
           fi
-          for target in darwin-arm64 darwin-x64 linux-x64; do
+          for target in darwin-arm64 darwin-x64 linux-x64 linux-arm64; do
             echo "Publishing @tloncorp/tlon-skill-$target..."
             cd npm/$target
             npm publish --access public $PROVENANCE

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tloncorp/tlon-skill-linux-arm64",
+  "version": "0.1.2",
+  "description": "Tlon skill binary for Linux arm64",
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "bin": {
+    "tlon": "tlon"
+  },
+  "files": ["tlon"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/tlon-skill"
+  },
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "optionalDependencies": {
     "@tloncorp/tlon-skill-darwin-arm64": "0.1.2",
     "@tloncorp/tlon-skill-darwin-x64": "0.1.2",
-    "@tloncorp/tlon-skill-linux-x64": "0.1.2"
+    "@tloncorp/tlon-skill-linux-x64": "0.1.2",
+    "@tloncorp/tlon-skill-linux-arm64": "0.1.2"
   },
   "devDependencies": {
     "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#main",


### PR DESCRIPTION
- Add npm/linux-arm64/package.json
- Update CI to build and publish linux-arm64
- Cross-compile from ubuntu-latest using bun