### PR TITLE
feat: add image upload command

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,16 @@ tlon-run notebook diary/~host/channel "Post Title" --image <url>
 
 ---
 
+### Upload
+
+Upload an image from a URL to Tlon storage. Returns the hosted URL.
+
+```bash
+tlon-run upload https://example.com/image.png
+```
+
+---
+
 ### Settings (OpenClaw Plugin Config)
 
 Manage OpenClaw's Tlon plugin config via Urbit settings-store. Changes apply immediately without gateway restart.

--- a/SKILL.md
+++ b/SKILL.md
@@ -154,6 +154,14 @@ tlon-run notebook diary/~host/slug "Title" --stdin            # Post from stdin
 tlon-run notebook diary/~host/slug "Title" --image <url>      # Post with image
 ```
 
+### Upload
+
+Upload an image from a URL to Tlon storage. Returns the hosted URL.
+
+```bash
+tlon-run upload <image-url>
+```
+
 ### Settings
 
 Manage bot settings (settings-store).

--- a/bin/tlon-run
+++ b/bin/tlon-run
@@ -37,6 +37,7 @@ Commands:
   dms {accept|decline}                         - DM invites
   posts {react|unreact|delete}                 - Channel post management
   notebook <nest> "Title" [--content file]     - Post to notebook/diary
+  upload <image-url>                           - Upload image to Tlon storage
   settings {get|set|delete}                    - Bot settings
   settings {allow-dm|remove-dm}               - DM allowlist
   settings {allow-channel|remove-channel}      - Channel watch list
@@ -676,6 +677,12 @@ case "$cmd" in
     exec node "$DIST_DIR/notebook-post.js" "$nest" "$title" "$@"
     ;;
 
+  upload)
+    url="${1:-}"
+    [ -n "$url" ] || { echo "error: missing image URL"; echo "usage: tlon-run upload <image-url>"; exit 2; }
+    exec node "$DIST_DIR/upload.js" "$url"
+    ;;
+
   settings)
     sub="${1:-}"
     shift || true
@@ -916,13 +923,13 @@ case "$cmd" in
 
   "")
     echo "error: no command specified"
-    echo "usage: tlon-run {activity|channels|contacts|groups|messages|dms|posts|notebook|settings|soul|user|tools|agents|bootstrap|heartbeat|identity|memory|click|help}"
+    echo "usage: tlon-run {activity|channels|contacts|groups|messages|dms|posts|notebook|upload|settings|soul|user|tools|agents|bootstrap|heartbeat|identity|memory|click|help}"
     exit 2
     ;;
 
   *)
     echo "error: unknown command '$cmd'"
-    echo "usage: tlon-run {activity|channels|contacts|groups|messages|dms|posts|notebook|settings|soul|user|tools|agents|bootstrap|heartbeat|identity|memory|click|help}"
+    echo "usage: tlon-run {activity|channels|contacts|groups|messages|dms|posts|notebook|upload|settings|soul|user|tools|agents|bootstrap|heartbeat|identity|memory|click|help}"
     exit 2
     ;;
 esac

--- a/extension/index.js
+++ b/extension/index.js
@@ -121,7 +121,7 @@ export default {
   register(api) {
     api.registerTool({
       name: "tlon_run",
-      description: "Tlon/Urbit API access and workspace editing. Commands: activity {mentions|replies|all|unreads} [--limit N], channels {dms|group-dms|groups|all}, contacts {list|self|get ~ship}, groups {list|info ~host/slug}, messages {dm ~ship|channel chat/~host/slug} [--limit N], dms {send|reply|react|delete}, posts {send|reply|react|delete}, settings {get|set|delete}, click <op>. Workspace: soul|user|tools|agents|bootstrap|heartbeat|identity|memory {read|replace|append} [content]. Multiline content with markdown is fine for replace/append.",
+      description: "Tlon/Urbit API access and workspace editing. Commands: activity {mentions|replies|all|unreads} [--limit N], channels {dms|group-dms|groups|all}, contacts {list|self|get ~ship}, groups {list|info ~host/slug}, messages {dm ~ship|channel chat/~host/slug} [--limit N], dms {send|reply|react|delete}, posts {send|reply|react|delete}, upload <image-url>, settings {get|set|delete}, click <op>. Workspace: soul|user|tools|agents|bootstrap|heartbeat|identity|memory {read|replace|append} [content]. Multiline content with markdown is fine for replace/append.",
       parameters: {
         type: "object",
         properties: {

--- a/scripts/upload.ts
+++ b/scripts/upload.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Upload an image from a URL to Tlon storage
+ *
+ * Usage:
+ *   npx ts-node scripts/upload.ts <image-url>
+ *
+ * Examples:
+ *   npx ts-node scripts/upload.ts https://example.com/image.png
+ */
+
+import { getConfig, scry, getCurrentShip } from "./urbit-client";
+
+const MEMEX_BASE_URL = "https://memex.tlon.network";
+
+const mimeToExt: Record<string, string> = {
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/png": ".png",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+  "image/heic": ".heic",
+  "image/heif": ".heif",
+};
+
+interface StorageConfiguration {
+  currentBucket: string;
+  region: string;
+  publicUrlBase: string;
+  service: string;
+  presignedUrl: string;
+}
+
+interface StorageCredentials {
+  endpoint: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+function getExtensionFromMimeType(mimeType?: string): string {
+  if (!mimeType) return ".jpg";
+  return mimeToExt[mimeType.toLowerCase()] || ".jpg";
+}
+
+async function getMemexUploadUrl(params: {
+  contentLength: number;
+  contentType: string;
+  fileName: string;
+}): Promise<{ hostedUrl: string; uploadUrl: string }> {
+  const ship = getCurrentShip().replace(/^~/, "");
+  const token = await scry<string>({ app: "genuine", path: "/secret" });
+
+  const endpoint = `${MEMEX_BASE_URL}/v1/${ship}/upload`;
+  const response = await fetch(endpoint, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token, ...params }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Memex upload request failed: ${response.status}`);
+  }
+
+  const data: { url?: string; filePath?: string } | null = await response.json();
+  if (!data?.url || !data?.filePath) {
+    throw new Error("Invalid response from Memex");
+  }
+
+  return { hostedUrl: data.filePath, uploadUrl: data.url };
+}
+
+export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
+  const response = await fetch(imageUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch image: ${response.status}`);
+  }
+
+  const blob = await response.blob();
+  const contentType = blob.type || "application/octet-stream";
+  const extension = getExtensionFromMimeType(contentType);
+
+  const ship = getCurrentShip().replace(/^~/, "");
+  const timestamp = Date.now();
+  const fileKey = `${ship}/${timestamp}-upload${extension}`;
+
+  const config = await scry<{ "storage-update": { configuration: StorageConfiguration } }>({
+    app: "storage",
+    path: "/configuration",
+  });
+
+  const credentials = await scry<{ "storage-update": { credentials: StorageCredentials } }>({
+    app: "storage",
+    path: "/credentials",
+  });
+
+  const storageConfig = config["storage-update"].configuration;
+  const storageCreds = credentials["storage-update"].credentials;
+
+  const isHosted = getConfig().url.includes("tlon.network");
+  const useMemex =
+    isHosted &&
+    (storageConfig.service === "presigned-url" ||
+      !storageCreds.accessKeyId ||
+      !storageCreds.endpoint ||
+      !storageCreds.secretAccessKey);
+
+  if (useMemex) {
+    const { hostedUrl, uploadUrl } = await getMemexUploadUrl({
+      contentLength: blob.size,
+      contentType,
+      fileName: fileKey,
+    });
+
+    const uploadResp = await fetch(uploadUrl, {
+      method: "PUT",
+      body: blob,
+      headers: {
+        "Cache-Control": "public, max-age=3600",
+        "Content-Type": contentType,
+      },
+    });
+
+    if (!uploadResp.ok) {
+      throw new Error(`Upload failed: ${uploadResp.status}`);
+    }
+
+    return hostedUrl;
+  }
+
+  // Self-hosted with custom S3: use presigned URL from storage agent
+  if (storageConfig.presignedUrl) {
+    const uploadResp = await fetch(storageConfig.presignedUrl, {
+      method: "PUT",
+      body: blob,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+
+    if (!uploadResp.ok) {
+      throw new Error(`Upload failed: ${uploadResp.status}`);
+    }
+
+    return storageConfig.presignedUrl.split("?")[0];
+  }
+
+  throw new Error(
+    "No upload method available. Ship must be hosted on tlon.network or have S3 storage configured."
+  );
+}
+
+async function main() {
+  const url = process.argv[2];
+
+  if (!url || url === "--help" || url === "-h") {
+    console.log(`Usage: upload <image-url>
+
+Fetches an image from a URL and uploads it to Tlon storage.
+Outputs the uploaded URL on success.
+
+Examples:
+  tlon-run upload https://example.com/image.png
+  tlon-run upload https://httpbin.org/image/png`);
+    process.exit(url ? 0 : 1);
+  }
+
+  getConfig(); // validate config exists
+
+  const uploadedUrl = await uploadImageFromUrl(url);
+  console.log(uploadedUrl);
+}
+
+main().catch((err) => {
+  console.error(`error: ${err.message || err}`);
+  process.exit(1);
+});

--- a/tool.json
+++ b/tool.json
@@ -1,6 +1,6 @@
 {
   "name": "tlon",
-  "description": "Tlon/Urbit API access. Use for checking activity, listing channels/groups, fetching message history, and looking up contacts.",
+  "description": "Tlon/Urbit API access. Use for checking activity, listing channels/groups, fetching message history, looking up contacts, and uploading images.",
   "command": "tlon-run",
   "parameters": {
     "type": "object",
@@ -23,6 +23,7 @@
     {"args": "groups info ~host-ship/group-slug"},
     {"args": "messages dm ~friend --limit 20"},
     {"args": "messages channel chat/~host/slug --limit 20"},
-    {"args": "--ship ~pinser-botter-nisrun-filnul activity mentions"}
+    {"args": "--ship ~pinser-botter-nisrun-filnul activity mentions"},
+    {"args": "upload https://example.com/image.png"}
   ]
 }


### PR DESCRIPTION
## Summary
- add `tlon-run upload <image-url>` command in `bin/tlon-run`
- add `scripts/upload.ts` to fetch image URLs and upload to Tlon storage
- document the command in `README.md` and `SKILL.md`
- update tool metadata descriptions/examples to include upload usage

## Notes
- rebased onto current `stable`
- reduced scope from prior closed PR by removing `@tloncorp/api` dependency and lockfile churn
- no `package.json` / `package-lock.json` changes in this PR

Closes/replaces #16.
