### PR TITLE
feat: add expose command for clearweb publishing

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tlon
-description: Interact with Tlon/Urbit API. Use for contacts (get/update profiles), listing channels/groups, fetching message history, posting to channels, sending DMs, and group management.
+description: Interact with Tlon/Urbit API. Use for contacts (get/update profiles), listing channels/groups, fetching message history, posting to channels, sending DMs, group management, and exposing content to the clearweb.
 ---
 
 # Tlon Skill
@@ -174,6 +174,24 @@ tlon dms delete ~sampel ~author/170.141...               # Delete a DM
 tlon dms accept ~sampel                                  # Accept DM invite
 tlon dms decline ~sampel                                 # Decline DM invite
 ```
+
+### Expose
+
+Publish Tlon content to the clearweb via the %expose agent.
+
+```bash
+tlon expose list                                         # List all exposed content
+tlon expose show chat/~host/slug/170.141...              # Expose a post publicly
+tlon expose hide chat/~host/slug/170.141...              # Hide an exposed post
+tlon expose check diary/~host/blog/170.141...            # Check if a post is exposed
+tlon expose url diary/~host/blog/170.141...              # Get the public URL
+```
+
+Cite path formats:
+- Simplified: `chat/~host/channel/170.141...` (auto-expands)
+- Full: `/1/chan/chat/~host/channel/msg/170.141...`
+
+Channel kinds map to content types: chat→msg, diary→note, heap→curio
 
 ### Posts
 

--- a/scripts/expose.ts
+++ b/scripts/expose.ts
@@ -1,0 +1,299 @@
+#!/usr/bin/env npx ts-node
+/**
+ * Manage exposed content on the clearweb via %expose agent
+ *
+ * Usage:
+ *   tlon expose list                    # List all exposed content
+ *   tlon expose show <cite-path>        # Expose a post publicly
+ *   tlon expose hide <cite-path>        # Hide an exposed post
+ *   tlon expose check <cite-path>       # Check if a post is exposed
+ *   tlon expose url <cite-path>         # Get the public URL for a post
+ *
+ * Cite path format: /1/chan/<kind>/~<host>/<channel>/<type>/<post-id>
+ * Example: /1/chan/chat/~nocsyx-lassul/my-channel/msg/170.141.184...
+ *
+ * You can also use a simplified format that will be expanded:
+ *   chat/~host/channel/170.141...  ->  /1/chan/chat/~host/channel/msg/170.141...
+ *   diary/~host/channel/170.141... ->  /1/chan/diary/~host/channel/note/170.141...
+ */
+
+import { poke, scry } from "@tloncorp/api";
+import { ensureClient, getConfig } from "./api-client";
+
+// Expand a simplified cite path to full format
+// chat/~host/channel/170.141... -> /1/chan/chat/~host/channel/msg/170.141...
+function expandCitePath(input: string): string {
+  // Already in full format
+  if (input.startsWith("/1/")) {
+    return input;
+  }
+
+  // Handle simplified format: kind/~host/channel/post-id
+  const parts = input.split("/");
+  if (parts.length < 4) {
+    throw new Error(
+      `Invalid cite path. Expected format: chat/~host/channel/post-id or /1/chan/chat/~host/channel/msg/post-id`
+    );
+  }
+
+  const kind = parts[0]; // chat, diary, heap
+  const host = parts[1]; // ~ship
+  const channel = parts[2]; // channel-name
+  const postId = parts.slice(3).join("/"); // post-id (may have dots)
+
+  // Determine the content type based on channel kind
+  let contentType: string;
+  switch (kind) {
+    case "chat":
+      contentType = "msg";
+      break;
+    case "diary":
+      contentType = "note";
+      break;
+    case "heap":
+      contentType = "curio";
+      break;
+    default:
+      throw new Error(`Unknown channel kind: ${kind}. Expected chat, diary, or heap.`);
+  }
+
+  return `/1/chan/${kind}/${host}/${channel}/${contentType}/${postId}`;
+}
+
+// Convert a cite path to a URL path for the public endpoint
+function citePathToUrlPath(citePath: string): string {
+  // Remove leading /1/ version prefix for URL
+  // /1/chan/chat/~host/channel/msg/123 -> /chan/chat/~host/channel/msg/123
+  if (citePath.startsWith("/1/")) {
+    return citePath.slice(2);
+  }
+  return citePath;
+}
+
+// List all exposed content
+async function listExposed(): Promise<string[]> {
+  try {
+    const result = await scry<unknown>({
+      app: "expose",
+      path: "/show",
+    });
+
+    // Result is a set of cites, represented as an array or set
+    if (Array.isArray(result)) {
+      return result.map((cite: any) => formatCite(cite));
+    }
+
+    // Handle set representation
+    if (result && typeof result === "object") {
+      const values = Object.values(result);
+      return values.map((cite: any) => formatCite(cite));
+    }
+
+    return [];
+  } catch (err: any) {
+    if (err?.message?.includes("404") || err?.message?.includes("not found")) {
+      return [];
+    }
+    throw err;
+  }
+}
+
+// Format a cite object to a readable path
+function formatCite(cite: any): string {
+  if (typeof cite === "string") {
+    return cite;
+  }
+
+  // Handle structured cite format from Urbit
+  // { chan: { nest: [kind, [ship, name]], wer: [type, id, ...] } }
+  if (cite.chan) {
+    const { nest, wer } = cite.chan;
+    const [kind, [ship, name]] = nest;
+    const werPath = Array.isArray(wer) ? wer.join("/") : wer;
+    return `/1/chan/${kind}/~${ship}/${name}/${werPath}`;
+  }
+
+  // Fallback: JSON stringify
+  return JSON.stringify(cite);
+}
+
+// Check if a specific cite is exposed
+async function checkExposed(citePath: string): Promise<boolean> {
+  const fullPath = expandCitePath(citePath);
+
+  try {
+    const result = await scry<boolean>({
+      app: "expose",
+      path: `/show${fullPath}`,
+    });
+    return !!result;
+  } catch (err: any) {
+    // 404 means not exposed
+    if (err?.message?.includes("404") || err?.message?.includes("not found")) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+// Expose a post publicly
+async function showPost(citePath: string): Promise<void> {
+  const fullPath = expandCitePath(citePath);
+
+  // Convert path string to path array for poke
+  // /1/chan/chat/~host/channel/msg/123 -> ["1", "chan", "chat", "~host", "channel", "msg", "123"]
+  const pathParts = fullPath.split("/").filter((p) => p.length > 0);
+
+  await poke({
+    app: "expose",
+    mark: "json",
+    json: {
+      show: pathParts,
+    },
+  });
+}
+
+// Hide an exposed post
+async function hidePost(citePath: string): Promise<void> {
+  const fullPath = expandCitePath(citePath);
+  const pathParts = fullPath.split("/").filter((p) => p.length > 0);
+
+  await poke({
+    app: "expose",
+    mark: "json",
+    json: {
+      hide: pathParts,
+    },
+  });
+}
+
+// Get the public URL for an exposed post
+function getPublicUrl(citePath: string, shipUrl: string): string {
+  const fullPath = expandCitePath(citePath);
+  const urlPath = citePathToUrlPath(fullPath);
+  return `${shipUrl}/expose${urlPath}`;
+}
+
+// CLI
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  const config = await ensureClient();
+
+  try {
+    switch (command) {
+      case "list": {
+        const exposed = await listExposed();
+        if (exposed.length === 0) {
+          console.log("No content currently exposed.");
+        } else {
+          console.log(`Exposed content (${exposed.length}):\n`);
+          for (const cite of exposed) {
+            const url = getPublicUrl(cite, config.url);
+            console.log(`  ${cite}`);
+            console.log(`    → ${url}\n`);
+          }
+        }
+        break;
+      }
+
+      case "show": {
+        const citePath = args[1];
+        if (!citePath) {
+          console.error("Usage: tlon expose show <cite-path>");
+          console.error("Example: tlon expose show chat/~host/channel/170.141...");
+          process.exit(1);
+        }
+
+        await showPost(citePath);
+        const fullPath = expandCitePath(citePath);
+        const url = getPublicUrl(fullPath, config.url);
+        console.log(`✓ Post exposed`);
+        console.log(`  Public URL: ${url}`);
+        break;
+      }
+
+      case "hide": {
+        const citePath = args[1];
+        if (!citePath) {
+          console.error("Usage: tlon expose hide <cite-path>");
+          process.exit(1);
+        }
+
+        await hidePost(citePath);
+        console.log("✓ Post hidden");
+        break;
+      }
+
+      case "check": {
+        const citePath = args[1];
+        if (!citePath) {
+          console.error("Usage: tlon expose check <cite-path>");
+          process.exit(1);
+        }
+
+        const isExposed = await checkExposed(citePath);
+        if (isExposed) {
+          const fullPath = expandCitePath(citePath);
+          const url = getPublicUrl(fullPath, config.url);
+          console.log(`✓ Post is exposed`);
+          console.log(`  Public URL: ${url}`);
+        } else {
+          console.log("✗ Post is not exposed");
+        }
+        break;
+      }
+
+      case "url": {
+        const citePath = args[1];
+        if (!citePath) {
+          console.error("Usage: tlon expose url <cite-path>");
+          process.exit(1);
+        }
+
+        const fullPath = expandCitePath(citePath);
+        const url = getPublicUrl(fullPath, config.url);
+        console.log(url);
+        break;
+      }
+
+      default:
+        console.log(`Usage: tlon expose <command>
+
+Manage public exposure of Tlon content via the %expose agent.
+
+Commands:
+  list                    List all exposed content with public URLs
+  show <cite-path>        Expose a post publicly
+  hide <cite-path>        Hide an exposed post
+  check <cite-path>       Check if a post is exposed
+  url <cite-path>         Get the public URL for a post
+
+Cite path formats:
+  Simplified:  chat/~host/channel/170.141...
+               diary/~host/channel/170.141...
+               heap/~host/channel/170.141...
+
+  Full:        /1/chan/chat/~host/channel/msg/170.141...
+               /1/chan/diary/~host/channel/note/170.141...
+               /1/chan/heap/~host/channel/curio/170.141...
+
+Examples:
+  tlon expose list
+  tlon expose show chat/~nocsyx-lassul/my-channel/170.141.184.507...
+  tlon expose hide chat/~nocsyx-lassul/my-channel/170.141.184.507...
+  tlon expose check diary/~nocsyx-lassul/blog/170.141.184.507...
+  tlon expose url diary/~nocsyx-lassul/blog/170.141.184.507...
+`);
+        process.exit(command ? 1 : 0);
+    }
+
+    process.exit(0);
+  } catch (error: any) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -32,6 +32,7 @@ Commands:
   channels     Channel listing and management (dms, groups, all, info, update, delete)
   contacts     Contact/profile management (list, get, self, sync, add, remove, update-profile)
   dms          Direct message operations (send, reply, react, unreact, delete, accept, decline)
+  expose       Manage public content exposure (list, show, hide, check, url)
   groups       Group management (list, create, info, invite, join, leave, delete, ...)
   messages     Message history and search (dm, channel, history, search)
   notebook     Post to diary/notebook channels
@@ -181,6 +182,10 @@ async function main() {
       }
       case "dms": {
         const mod = await import("./dms");
+        break;
+      }
+      case "expose": {
+        const mod = await import("./expose");
         break;
       }
       case "groups": {


### PR DESCRIPTION
Adds `tlon expose` command to manage public content exposure via the %expose agent.

## Commands

- `tlon expose list` — List all exposed content with public URLs
- `tlon expose show <cite>` — Expose a post publicly
- `tlon expose hide <cite>` — Hide an exposed post
- `tlon expose check <cite>` — Check if a post is exposed
- `tlon expose url <cite>` — Get the public URL for a post

## Cite Path Formats

Supports simplified paths that auto-expand:
- `chat/~host/channel/170.141...` → `/1/chan/chat/~host/channel/msg/170.141...`
- `diary/~host/channel/170.141...` → `/1/chan/diary/~host/channel/note/170.141...`
- `heap/~host/channel/170.141...` → `/1/chan/heap/~host/channel/curio/170.141...`

## Testing

```bash
bun run scripts/main.ts expose list
bun run scripts/main.ts expose --help
```