### PR TITLE
ci: only publish when tag is pushed to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.dry_run == 'false'
+    # Only run on tags pushed directly to master, or manual workflow_dispatch
+    if: (startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push' && github.ref_name == 'master') || github.event.inputs.dry_run == 'false'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Changes the publish workflow to only run when a tag is pushed directly to the master branch, not from PRs or other branches.

Previously, tags on any branch would trigger publishing. Now it requires:
- Tag starts with 'v'
- Push event (not PR)- Branch is 'master'This prevents accidental publishes from PR branches.