### PR TITLE
feat: show nicknames in messages, activity, and channels

### DIFF
--- a/scripts/activity.ts
+++ b/scripts/activity.ts
@@ -10,7 +10,7 @@
  */
 
 import { getInitialActivity, getGroupAndChannelUnreads, getTextContent } from "@tloncorp/api";
-import { ensureClient } from "./api-client";
+import { buildNicknameMap, ensureClient, formatShipWithNickname } from "./api-client";
 
 interface ActivityEvent {
   id: string;
@@ -67,12 +67,12 @@ function formatTime(timeStr: string | number): string {
 }
 
 // Format an activity event for display
-function formatEvent(event: ActivityEvent): string {
+function formatEvent(event: ActivityEvent, nicknameMap: Map<string, string>): string {
   const lines: string[] = [];
   const timeStr = formatTime(event.timestamp);
   
   if (event.type === "post") {
-    const author = event.authorId || "unknown";
+    const author = formatShipWithNickname(event.authorId || "unknown", nicknameMap);
     const text = extractText(event.content);
     const mention = event.isMention ? " [MENTION]" : "";
     lines.push(`📝 Post${mention} by ${author} in ${event.channelId}`);
@@ -82,7 +82,7 @@ function formatEvent(event: ActivityEvent): string {
   }
   
   if (event.type === "reply") {
-    const author = event.authorId || "unknown";
+    const author = formatShipWithNickname(event.authorId || "unknown", nicknameMap);
     const text = extractText(event.content);
     const mention = event.isMention ? " [MENTION]" : "";
     lines.push(`💬 Reply${mention} by ${author} in ${event.channelId}`);
@@ -92,7 +92,7 @@ function formatEvent(event: ActivityEvent): string {
   }
   
   if (event.type === "dm-post") {
-    const author = event.authorId || "unknown";
+    const author = formatShipWithNickname(event.authorId || "unknown", nicknameMap);
     const text = extractText(event.content);
     const mention = event.isMention ? " [MENTION]" : "";
     lines.push(`📨 DM${mention} from ${author}`);
@@ -102,7 +102,7 @@ function formatEvent(event: ActivityEvent): string {
   }
   
   if (event.type === "dm-reply") {
-    const author = event.authorId || "unknown";
+    const author = formatShipWithNickname(event.authorId || "unknown", nicknameMap);
     const text = extractText(event.content);
     const mention = event.isMention ? " [MENTION]" : "";
     lines.push(`💬 DM Reply${mention} from ${author}`);
@@ -112,25 +112,29 @@ function formatEvent(event: ActivityEvent): string {
   }
   
   if (event.type === "group-ask") {
-    lines.push(`🙋 Join request from ${event.groupEventUserId || "unknown"}`);
+    const user = formatShipWithNickname(event.groupEventUserId || "unknown", nicknameMap);
+    lines.push(`🙋 Join request from ${user}`);
     if (event.groupId) lines.push(`   Group: ${event.groupId}`);
     lines.push(`   Time: ${timeStr}`);
   }
   
   if (event.type === "group-join") {
-    lines.push(`👋 ${event.groupEventUserId || "unknown"} joined`);
+    const user = formatShipWithNickname(event.groupEventUserId || "unknown", nicknameMap);
+    lines.push(`👋 ${user} joined`);
     if (event.groupId) lines.push(`   Group: ${event.groupId}`);
     lines.push(`   Time: ${timeStr}`);
   }
   
   if (event.type === "group-invite") {
-    lines.push(`📩 Invite from ${event.groupEventUserId || "unknown"}`);
+    const user = formatShipWithNickname(event.groupEventUserId || "unknown", nicknameMap);
+    lines.push(`📩 Invite from ${user}`);
     if (event.groupId) lines.push(`   Group: ${event.groupId}`);
     lines.push(`   Time: ${timeStr}`);
   }
   
   if (event.type === "contact") {
-    lines.push(`👤 Contact update from ${event.contactUserId || "unknown"}`);
+    const user = formatShipWithNickname(event.contactUserId || "unknown", nicknameMap);
+    lines.push(`👤 Contact update from ${user}`);
     if (event.contactUpdateType) {
       lines.push(`   Update: ${event.contactUpdateType}`);
     }
@@ -144,7 +148,11 @@ async function getActivity(bucket: 'all' | 'mentions' | 'replies', limit: number
   // Initialize client (validates env vars)
   await ensureClient();
 
-  const { events } = await getInitialActivity();
+  const [{ events }, nicknameMap] = await Promise.all([
+    getInitialActivity(),
+    buildNicknameMap(),
+  ]);
+
   const bucketEvents = events
     .filter((event) => event.bucketId === bucket)
     .sort((a, b) => b.timestamp - a.timestamp)
@@ -158,7 +166,7 @@ async function getActivity(bucket: 'all' | 'mentions' | 'replies', limit: number
   console.log(`\n=== ${bucket.toUpperCase()} (${bucketEvents.length} events) ===\n`);
 
   for (const event of bucketEvents) {
-    const formatted = formatEvent(event as ActivityEvent);
+    const formatted = formatEvent(event as ActivityEvent, nicknameMap);
     if (formatted) {
       console.log(formatted);
       console.log("");

--- a/scripts/api-client.ts
+++ b/scripts/api-client.ts
@@ -6,7 +6,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { configureClient, preSig, subscribe } from "@tloncorp/api";
+import { configureClient, getContacts, preSig, subscribe } from "@tloncorp/api";
 
 export interface UrbitConfig {
   url: string;
@@ -202,4 +202,32 @@ export async function getCurrentShip(): Promise<string> {
  */
 export function normalizeShip(ship: string): string {
   return preSig(ship);
+}
+
+/**
+ * Build a map of ship -> nickname from contacts.
+ * Returns empty map if contacts unavailable.
+ */
+export async function buildNicknameMap(): Promise<Map<string, string>> {
+  const nicknameMap = new Map<string, string>();
+  try {
+    const contacts = await getContacts();
+    for (const contact of contacts) {
+      const nickname = contact.nickname ?? contact.peerNickname;
+      if (nickname) {
+        nicknameMap.set(contact.id, nickname);
+      }
+    }
+  } catch {
+    // Contacts unavailable, continue without nicknames
+  }
+  return nicknameMap;
+}
+
+/**
+ * Format a ship with optional nickname: "~ship (nickname)" or just "~ship"
+ */
+export function formatShipWithNickname(ship: string, nicknameMap: Map<string, string>): string {
+  const nickname = nicknameMap.get(ship);
+  return nickname ? `${ship} (${nickname})` : ship;
 }

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -14,23 +14,34 @@
 
 import { deleteChannel, getGroups, getInitData, updateChannel } from "@tloncorp/api";
 import type { Channel as ApiChannel, Group as ApiGroup } from "@tloncorp/api";
-import { ensureClient, getCurrentShip } from "./api-client";
+import { buildNicknameMap, ensureClient, formatShipWithNickname, getCurrentShip } from "./api-client";
 
 // Get DMs
 async function getDms() {
-  const init = await getInitData();
+  const [init, nicknameMap] = await Promise.all([
+    getInitData(),
+    buildNicknameMap(),
+  ]);
   const dms = init.channels.filter((channel) => channel.type === "dm");
-  return dms.map((dm) => ({
-    type: "dm",
-    id: dm.id,
-    contact: dm.contactId || dm.id,
-  }));
+  return dms.map((dm) => {
+    const contact = dm.contactId || dm.id;
+    const nickname = nicknameMap.get(contact);
+    return {
+      type: "dm",
+      id: dm.id,
+      contact,
+      ...(nickname && { nickname }),
+    };
+  });
 }
 
 // Get group DMs (clubs)
 async function getGroupDms() {
   const currentShip = await getCurrentShip();
-  const init = await getInitData();
+  const [init, nicknameMap] = await Promise.all([
+    getInitData(),
+    buildNicknameMap(),
+  ]);
   const groupDms = init.channels.filter((channel) => channel.type === "groupDm");
 
   return groupDms.map((dm) => {
@@ -45,8 +56,14 @@ async function getGroupDms() {
       id: dm.id,
       title: dm.title || "Untitled",
       description: dm.description || "",
-      members: joined.map((member) => member.contactId),
-      invited: invited.map((member) => member.contactId),
+      members: joined.map((member) => {
+        const nickname = nicknameMap.get(member.contactId);
+        return nickname ? `${member.contactId} (${nickname})` : member.contactId;
+      }),
+      invited: invited.map((member) => {
+        const nickname = nicknameMap.get(member.contactId);
+        return nickname ? `${member.contactId} (${nickname})` : member.contactId;
+      }),
       status: isJoined ? "joined" : isInvited ? "invited" : "unknown",
     };
   });

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -34,7 +34,6 @@ import {
   createGroup,
   deleteGroup,
   deleteGroupRole,
-  getContacts,
   getCurrentUserId,
   getGroup,
   getGroups,
@@ -50,7 +49,7 @@ import {
   updateGroupRole,
 } from "@tloncorp/api";
 import type { Group } from "@tloncorp/api";
-import { ensureClient, getCurrentShip, normalizeShip } from "./api-client";
+import { buildNicknameMap, ensureClient, formatShipWithNickname, getCurrentShip, normalizeShip } from "./api-client";
 
 // Generate a random short ID for the group
 function generateGroupSlug(): string {
@@ -84,29 +83,6 @@ async function listGroups() {
     }
     console.log("");
   }
-}
-
-// Build a map of ship -> nickname from contacts
-async function buildNicknameMap(): Promise<Map<string, string>> {
-  const nicknameMap = new Map<string, string>();
-  try {
-    const contacts = await getContacts();
-    for (const contact of contacts) {
-      const nickname = contact.nickname ?? contact.peerNickname;
-      if (nickname) {
-        nicknameMap.set(contact.id, nickname);
-      }
-    }
-  } catch {
-    // Contacts unavailable, continue without nicknames
-  }
-  return nicknameMap;
-}
-
-// Format a ship with optional nickname
-function formatShipWithNickname(ship: string, nicknameMap: Map<string, string>): string {
-  const nickname = nicknameMap.get(ship);
-  return nickname ? `${ship} (${nickname})` : ship;
 }
 
 // Get info about a specific group

--- a/scripts/messages.ts
+++ b/scripts/messages.ts
@@ -19,7 +19,7 @@ import {
   searchChannel,
 } from "@tloncorp/api";
 import type { ContentReference, Post } from "@tloncorp/api";
-import { ensureClient, normalizeShip } from "./api-client";
+import { buildNicknameMap, ensureClient, formatShipWithNickname, normalizeShip } from "./api-client";
 
 // Extract text content from a Story
 function extractText(content: any): string {
@@ -93,7 +93,7 @@ async function resolveCites(post: Post): Promise<string[]> {
   return citeTexts;
 }
 
-async function printPosts(posts: Post[], resolve: boolean) {
+async function printPosts(posts: Post[], resolve: boolean, nicknameMap: Map<string, string>) {
   if (!posts.length) {
     console.log("No messages found.");
     return;
@@ -102,7 +102,7 @@ async function printPosts(posts: Post[], resolve: boolean) {
   const sorted = [...posts].sort((a, b) => a.sentAt - b.sentAt);
 
   for (const post of sorted) {
-    const author = post.authorId || "unknown";
+    const author = formatShipWithNickname(post.authorId || "unknown", nicknameMap);
     const time = formatTime(post.sentAt);
     const text = extractText(post.content);
     const replySuffix = post.parentId ? ` (reply to ${post.parentId})` : "";
@@ -137,15 +137,18 @@ async function fetchDmMessages(
   console.log(`Limit: ${limit}${resolveCites ? " (resolving quotes)" : ""}\n`);
 
   try {
-    const data = await getChannelPosts({
-      channelId: normalizedShip,
-      mode: "newest",
-      count: limit,
-      includeReplies: true,
-    });
+    const [data, nicknameMap] = await Promise.all([
+      getChannelPosts({
+        channelId: normalizedShip,
+        mode: "newest",
+        count: limit,
+        includeReplies: true,
+      }),
+      buildNicknameMap(),
+    ]);
 
     console.log(`=== DMs with ${normalizedShip} (${data.posts.length}) ===\n`);
-    await printPosts(data.posts, resolveCites);
+    await printPosts(data.posts, resolveCites, nicknameMap);
   } catch (error: any) {
     console.error(`Error fetching DMs: ${error.message}`);
   }
@@ -163,15 +166,18 @@ async function fetchMessages(
   console.log(`Limit: ${limit}${resolveCites ? " (resolving quotes)" : ""}\n`);
 
   try {
-    const data = await getChannelPosts({
-      channelId: channel,
-      mode: "newest",
-      count: limit,
-      includeReplies: true,
-    });
+    const [data, nicknameMap] = await Promise.all([
+      getChannelPosts({
+        channelId: channel,
+        mode: "newest",
+        count: limit,
+        includeReplies: true,
+      }),
+      buildNicknameMap(),
+    ]);
 
     console.log(`=== Messages in ${channel} (${data.posts.length}) ===\n`);
-    await printPosts(data.posts, resolveCites);
+    await printPosts(data.posts, resolveCites, nicknameMap);
   } catch (error: any) {
     console.error(`Error fetching messages: ${error.message}`);
     console.log("Note: Check that the channel path is correct (e.g., chat/~host/slug)");
@@ -185,10 +191,13 @@ async function searchMessages(query: string, channel: string): Promise<void> {
   console.log(`Searching "${query}" in: ${channel}\n`);
 
   try {
-    const results = await searchChannel({
-      channelId: channel,
-      query,
-    });
+    const [results, nicknameMap] = await Promise.all([
+      searchChannel({
+        channelId: channel,
+        query,
+      }),
+      buildNicknameMap(),
+    ]);
 
     if (!results.posts.length) {
       console.log("No results found.");
@@ -196,7 +205,7 @@ async function searchMessages(query: string, channel: string): Promise<void> {
     }
 
     console.log(`Found ${results.posts.length} results:\n`);
-    await printPosts(results.posts, false);
+    await printPosts(results.posts, false, nicknameMap);
   } catch (error: any) {
     console.error(`Error searching messages: ${error.message}`);
   }


### PR DESCRIPTION
Adds nickname display to several commands for better readability.

**Base:** This PR builds on #50 and uses its shared helpers.

## Changes

### api-client.ts
- Added shared `buildNicknameMap()` and `formatShipWithNickname()` helpers

### messages.ts
- `messages dm` / `messages channel` / `messages search` now show author nicknames

**Before:** `~nocsyx-lassul @ 1/29/2026, 7:02:38 PM`
**After:** `~nocsyx-lassul (hunter ⚗️) @ 1/29/2026, 7:02:38 PM`

### activity.ts
- All event types (posts, replies, DMs, joins, invites, contacts) now show nicknames

**Before:** `📝 Post by ~malmur-halmex in chat/~bolbex-fogdys/tlon-general`
**After:** `📝 Post by ~malmur-halmex (bill) in chat/~bolbex-fogdys/tlon-general`

### channels.ts
- `channels dms` now includes `nickname` field in JSON output
- `channels group-dms` shows nicknames for members/invited lists

### groups.ts
- Updated to use shared helpers from api-client.ts (removes duplication)

## Performance
All nickname fetches run in parallel with primary data fetch (no added latency).