### PR TITLE
chore: bump version to 0.1.12

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-arm64",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Tlon skill binary for macOS ARM64",
   "os": [
     "darwin"

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-x64",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Tlon skill binary for macOS x64",
   "os": [
     "darwin"

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-linux-arm64",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Tlon skill binary for Linux arm64",
   "os": [
     "linux"

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-linux-x64",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Tlon skill binary for Linux x64",
   "os": [
     "linux"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Tlon/Urbit skill for OpenClaw agents",
   "type": "module",
   "bin": {
@@ -20,10 +20,10 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "optionalDependencies": {
-    "@tloncorp/tlon-skill-darwin-arm64": "0.1.11",
-    "@tloncorp/tlon-skill-darwin-x64": "0.1.11",
-    "@tloncorp/tlon-skill-linux-x64": "0.1.11",
-    "@tloncorp/tlon-skill-linux-arm64": "0.1.11"
+    "@tloncorp/tlon-skill-darwin-arm64": "0.1.12",
+    "@tloncorp/tlon-skill-darwin-x64": "0.1.12",
+    "@tloncorp/tlon-skill-linux-x64": "0.1.12",
+    "@tloncorp/tlon-skill-linux-arm64": "0.1.12"
   },
   "devDependencies": {
     "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#main",


### PR DESCRIPTION
Bumps version to include the new channel permission commands (add-writers, del-writers, add-readers, del-readers) from #49.