### PR TITLE
perf: only subscribe to needed channels

### DIFF
--- a/scripts/activity.ts
+++ b/scripts/activity.ts
@@ -141,8 +141,6 @@ function formatEvent(event: ActivityEvent): string {
 }
 
 async function getActivity(bucket: 'all' | 'mentions' | 'replies', limit: number = 10) {
-  // Initialize client (validates env vars)
-  await ensureClient();
 
   const { events } = await getInitialActivity();
   const bucketEvents = events
@@ -167,8 +165,6 @@ async function getActivity(bucket: 'all' | 'mentions' | 'replies', limit: number
 }
 
 async function getUnreads() {
-  // Initialize client (validates env vars)
-  await ensureClient();
 
   const activity = await getGroupAndChannelUnreads();
 
@@ -216,6 +212,7 @@ async function getUnreads() {
 async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
+  await ensureClient();
   
   // Parse --limit flag
   let limit = 10;

--- a/scripts/api-client.ts
+++ b/scripts/api-client.ts
@@ -140,42 +140,51 @@ function loadConfigFile(filePath: string): UrbitConfig {
 
 /**
  * Set up subscriptions required for trackedPoke to receive acks.
- * These must match the paths used by trackedPoke calls in @tloncorp/api.
+ * Only subscribes to requested apps to minimize overhead.
  */
-async function setupSubscriptions(): Promise<void> {
+async function setupSubscriptions(subs: Array<'groups' | 'channels' | 'chat' | 'lanyard'>): Promise<void> {
   if (subscribed) return;
-  
-  // groups mutations (createGroup, deleteGroup, updateGroupMeta, etc.)
-  await subscribe(
-    { app: 'groups', path: '/v1/groups' },
-    () => {}
-  );
-  
-  // channel mutations (createChannel, updateChannel, deleteChannel, etc.)
-  await subscribe(
-    { app: 'channels', path: '/v2' },
-    () => {}
-  );
-  
-  // DM mutations (updateDMMeta)
-  await subscribe(
-    { app: 'chat', path: '/' },
-    () => {}
-  );
-  
-  // lanyard/attestation mutations (phone verify, twitter attestation, etc.)
-  await subscribe(
-    { app: 'lanyard', path: '/v1/records' },
-    () => {}
-  );
-  
+
+  if (subs.includes('groups')) {
+    // groups mutations (createGroup, deleteGroup, updateGroupMeta, etc.)
+    await subscribe(
+      { app: 'groups', path: '/v1/groups' },
+      () => {}
+    );
+  }
+
+  if (subs.includes('channels')) {
+    // channel mutations (createChannel, updateChannel, deleteChannel, etc.)
+    await subscribe(
+      { app: 'channels', path: '/v2' },
+      () => {}
+    );
+  }
+
+  if (subs.includes('chat')) {
+    // DM mutations (updateDMMeta)
+    await subscribe(
+      { app: 'chat', path: '/' },
+      () => {}
+    );
+  }
+
+  if (subs.includes('lanyard')) {
+    // lanyard/attestation mutations (phone verify, twitter attestation, etc.)
+    await subscribe(
+      { app: 'lanyard', path: '/v1/records' },
+      () => {}
+    );
+  }
+
   subscribed = true;
 }
 
 /**
  * Ensure @tloncorp/api client is configured, connected, and subscribed.
+ * Pass required subscription apps to minimize connection overhead.
  */
-export async function ensureClient(): Promise<UrbitConfig> {
+export async function ensureClient(subs: Array<'groups' | 'channels' | 'chat' | 'lanyard'> = []): Promise<UrbitConfig> {
   const cfg = getConfig();
   if (!initialized) {
     await configureClient({
@@ -183,7 +192,7 @@ export async function ensureClient(): Promise<UrbitConfig> {
       shipUrl: cfg.url,
       getCode: async () => cfg.code
     });
-    await setupSubscriptions();
+    await setupSubscriptions(subs);
     initialized = true;
   }
   return cfg;
@@ -193,7 +202,7 @@ export async function ensureClient(): Promise<UrbitConfig> {
  * Get current ship name (with ~)
  */
 export async function getCurrentShip(): Promise<string> {
-  const cfg = await ensureClient();
+  const cfg = await ensureClient([]);
   return preSig(cfg.ship);
 }
 

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -228,7 +228,6 @@ async function deleteChannelByNest(nest: string) {
 }
 
 async function getGroupsApi(): Promise<ApiGroup[]> {
-  await ensureClient();
   return getGroups();
 }
 
@@ -305,7 +304,7 @@ async function main() {
   const command = args[0];
 
   try {
-    await ensureClient();
+    await ensureClient(['channels']);
     switch (command) {
       case "dms": {
         const dms = await getDms();

--- a/scripts/dms.ts
+++ b/scripts/dms.ts
@@ -216,7 +216,7 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
-  await ensureClient();
+  await ensureClient(['chat']);
 
   switch (command) {
     case "send": {

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -245,7 +245,6 @@ async function joinGroupById(groupId: string) {
 
 // Delete a group (must be host)
 async function deleteGroupById(groupId: string) {
-  await ensureClient();
   console.log(`Deleting group ${groupId}...`);
 
   await deleteGroup(groupId);
@@ -492,7 +491,7 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
-  await ensureClient();
+  await ensureClient(['groups', 'channels']);
 
   switch (command) {
     case "list":

--- a/scripts/messages.ts
+++ b/scripts/messages.ts
@@ -130,7 +130,6 @@ async function fetchDmMessages(
   limit: number = 20,
   resolveCites: boolean = false
 ): Promise<void> {
-  await ensureClient();
   const normalizedShip = normalizeShip(ship);
 
   console.log(`Fetching DMs with: ${normalizedShip}`);
@@ -157,7 +156,6 @@ async function fetchMessages(
   limit: number = 20,
   resolveCites: boolean = false
 ): Promise<void> {
-  await ensureClient();
 
   console.log(`Fetching messages from: ${channel}`);
   console.log(`Limit: ${limit}${resolveCites ? " (resolving quotes)" : ""}\n`);
@@ -180,7 +178,6 @@ async function fetchMessages(
 
 // Search messages in a channel
 async function searchMessages(query: string, channel: string): Promise<void> {
-  await ensureClient();
 
   console.log(`Searching "${query}" in: ${channel}\n`);
 
@@ -206,6 +203,8 @@ async function searchMessages(query: string, channel: string): Promise<void> {
 async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
+
+  await ensureClient();
 
   // Parse --limit flag
   let limit = 20;

--- a/scripts/notebook-post.ts
+++ b/scripts/notebook-post.ts
@@ -106,7 +106,7 @@ Examples:
   console.log(`Title: ${title}`);
   if (image) console.log(`Image: ${image}`);
 
-  await ensureClient();
+  await ensureClient(['channels']);
   const result = await postToNotebook(nest, title, content, image);
 
   if (result.success) {

--- a/scripts/posts.ts
+++ b/scripts/posts.ts
@@ -184,7 +184,7 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
-  await ensureClient();
+  await ensureClient(['channels']);
 
   try {
     switch (command) {


### PR DESCRIPTION
This was an attempt to cleanup how long the skill takes for tasks. For basic reading tasks this should speed up a decent bit by making less requests. Also adds a cleanup step to the CLI to make sure we remove the session we created from auth. In the future we may want to make it so that the tool is callable with a valid cookie so we can step the auth step entirely.