### PR TITLE
feat: cookie-based auth with automatic caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-linux-x64/-/tlon-skill-l
 
 **Option 1: CLI flags (highest priority)**
 ```bash
-# Pass credentials directly
+# Cookie-based auth (fastest - ship parsed from cookie)
+tlon --url https://your-ship.tlon.network --cookie "urbauth-~your-ship=0v..." contacts self
+
+# Code-based auth (requires all three)
 tlon --url https://your-ship.tlon.network --ship ~your-ship --code sampel-ticlyt-migfun-falmel contacts self
 
 # Or use a config file
@@ -35,11 +38,20 @@ tlon --config ~/ships/my-ship.json contacts self
 
 Config file format:
 ```json
+// Cookie-based (ship derived from cookie)
+{"url": "https://your-ship.tlon.network", "cookie": "urbauth-~your-ship=0v..."}
+
+// Code-based
 {"url": "https://your-ship.tlon.network", "ship": "~your-ship", "code": "sampel-ticlyt-migfun-falmel"}
 ```
 
 **Option 2: Environment variables**
 ```bash
+# Cookie-based (ship derived from cookie)
+export URBIT_URL="https://your-ship.tlon.network"
+export URBIT_COOKIE="urbauth-~your-ship=0v..."
+
+# Code-based
 export URBIT_URL="https://your-ship.tlon.network"
 export URBIT_SHIP="~your-ship"
 export URBIT_CODE="sampel-ticlyt-migfun-falmel"
@@ -49,16 +61,41 @@ export URBIT_CODE="sampel-ticlyt-migfun-falmel"
 
 If you have OpenClaw configured with a Tlon channel, credentials are loaded automatically.
 
+## Cookie Caching
+
+The skill automatically caches auth cookies to `~/.tlon/cache/<ship>.json` after successful authentication.
+
+```bash
+# First time - auth and cache
+$ tlon --url https://zod.tlon.network --ship ~zod --code abcd-efgh contacts self
+Note: Credentials cached for ~zod. Next time just run: tlon <command>
+
+# After that - no flags needed!
+$ tlon contacts self
+
+# Multiple cached ships? Specify which one:
+$ tlon --ship ~zod contacts self
+```
+
+Clear cache: `rm ~/.tlon/cache/*.json`
+
+## Cookie vs Code Authentication
+
+- **Cookie-based auth**: Uses a pre-authenticated session cookie. Faster since it skips login.
+- **Code-based auth**: Performs a login request to get a session cookie.
+
+The ship name is embedded in the cookie (`urbauth-~ship=...`), so you don't need to specify it separately with cookie auth.
+
 ## Multi-Ship Usage
 
-If you have credentials for multiple ships, you can operate on behalf of any of them by passing their credentials via CLI flags. This is useful for managing multiple identities, bot operations, or moon management:
+If you have credentials for multiple ships, you can operate on behalf of any of them:
 
 ```bash
 # Act as a different ship
 tlon --config ~/ships/bot.json channels groups
 
 # Or pass credentials directly
-tlon --url https://bot.tlon.network --ship ~bot-ship --code bot-code contacts self
+tlon --url https://bot.tlon.network --cookie "urbauth-~bot=0v..." contacts self
 ```
 
 ## Usage

--- a/SKILL.md
+++ b/SKILL.md
@@ -23,21 +23,37 @@ curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-arm64/-/tlon-skil
 
 Replace `darwin-arm64` with `darwin-x64` or `linux-x64` as needed.
 
+
 ## Configuration
 
 **CLI Flags (highest priority):**
 ```bash
-# Pass all three credentials directly
+# Cookie-based auth (fastest - ship parsed from cookie name)
+tlon --url https://your-ship.tlon.network --cookie "urbauth-~your-ship=0v..." <command>
+
+# Code-based auth (requires url + ship + code)
 tlon --url https://your-ship.tlon.network --ship ~your-ship --code sampel-ticlyt-migfun-falmel <command>
 
 # Or load from a JSON config file
 tlon --config ~/ships/my-ship.json <command>
 ```
 
-Config file format: `{"url": "...", "ship": "~...", "code": "..."}`
+Config file format:
+```json
+// Cookie-based (ship derived from cookie)
+{"url": "...", "cookie": "urbauth-~ship=..."}
+
+// Code-based
+{"url": "...", "ship": "~...", "code": "..."}
+```
 
 **Environment Variables:**
 ```bash
+# Cookie-based (ship derived from cookie)
+export URBIT_URL="https://your-ship.tlon.network"
+export URBIT_COOKIE="urbauth-~your-ship=0v..."
+
+# Code-based
 export URBIT_URL="https://your-ship.tlon.network"
 export URBIT_SHIP="~your-ship"
 export URBIT_CODE="sampel-ticlyt-migfun-falmel"
@@ -45,7 +61,43 @@ export URBIT_CODE="sampel-ticlyt-migfun-falmel"
 
 **OpenClaw:** If configured with a Tlon channel, credentials load automatically.
 
-**Resolution order:** CLI flags → `TLON_CONFIG_FILE` → `TLON_SHIP`+`TLON_SKILL_DIR` → `URBIT_*` env vars → OpenClaw config
+**Resolution order:** CLI flags → `TLON_CONFIG_FILE` → `URL + COOKIE` → `URL + SHIP + CODE` → `--ship` with cache → OpenClaw config → cached ships (auto-select if only one)
+
+**Cookie vs Code:**
+- **Cookie-based:** Uses pre-authenticated session cookie. Ship is parsed from the cookie name (`urbauth-~ship=...`). Fastest option.
+- **Code-based:** Performs login to get session cookie. Requires URL + ship + code.
+
+You can provide both cookie and code — cookie is used first, code serves as fallback if cookie expires.
+
+## Cookie Caching
+
+The skill automatically caches auth cookies to `~/.tlon/cache/<ship>.json` after successful authentication. This makes subsequent invocations much faster by skipping the login request.
+
+**How it works:**
+```bash
+# First time - authenticates and caches
+$ tlon --url https://zod.tlon.network --ship ~zod --code abcd-efgh contacts self
+~zod
+Note: Credentials cached for ~zod. Next time just run: tlon <command>
+
+# After that - no flags needed (if only one cached ship)
+$ tlon contacts self
+~zod
+
+# With multiple cached ships - specify which one
+$ tlon --ship ~zod contacts self
+$ tlon --ship ~bus contacts self
+```
+
+**Cache behavior:**
+- Cached cookies are URL-specific (won't use a cookie for the wrong host)
+- If only one ship is cached, it's auto-selected (no flags needed)
+- If multiple ships are cached, you'll be prompted to specify with `--ship`
+- The skill reminds you when you pass credentials that aren't needed
+
+**Clear cache:** `rm ~/.tlon/cache/*.json`
+
+
 
 ## Multi-Ship Usage
 

--- a/scripts/api-client.ts
+++ b/scripts/api-client.ts
@@ -6,17 +6,132 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { configureClient, preSig, subscribe } from "@tloncorp/api";
+import { configureClient, preSig, subscribe, Urbit, client } from "@tloncorp/api";
 
 export interface UrbitConfig {
   url: string;
   ship: string;
+  /** Access code (required unless cookie is provided/cached) */
   code: string;
+  /** Pre-authenticated cookie (optional, bypasses code-based auth) */
+  cookie?: string;
+}
+
+interface CachedAuth {
+  url: string;
+  ship: string;
+  cookie: string;
+  cachedAt: number;
 }
 
 let initialized = false;
 let subscribed = false;
 let cachedConfig: UrbitConfig | null = null;
+
+const CACHE_DIR = path.join(os.homedir(), ".tlon", "cache");
+
+// Track if user provided explicit credentials (for helpful warnings)
+let userProvidedCode = false;
+let userProvidedUrl = false;
+
+/**
+ * Get path to cookie cache file for a ship
+ */
+function getCachePath(ship: string): string {
+  return path.join(CACHE_DIR, `${ship.replace(/^~/, "")}.json`);
+}
+
+/**
+ * Get all cached ship entries
+ */
+function getCachedShips(): CachedAuth[] {
+  try {
+    if (!fs.existsSync(CACHE_DIR)) return [];
+    
+    const files = fs.readdirSync(CACHE_DIR).filter(f => f.endsWith(".json"));
+    const entries: CachedAuth[] = [];
+    
+    for (const file of files) {
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(CACHE_DIR, file), "utf-8"));
+        if (data.url && data.ship && data.cookie) {
+          entries.push(data);
+        }
+      } catch {
+        // Skip invalid cache files
+      }
+    }
+    
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get cached cookie for a ship+url combo
+ */
+function getCachedCookie(url: string, ship: string): string | null {
+  try {
+    const cachePath = getCachePath(ship);
+    if (!fs.existsSync(cachePath)) return null;
+    
+    const data: CachedAuth = JSON.parse(fs.readFileSync(cachePath, "utf-8"));
+    
+    // Verify URL matches (don't use cookie meant for different host)
+    if (data.url !== url) return null;
+    
+    return data.cookie || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get cached entry for a ship (any url)
+ */
+function getCachedEntry(ship: string): CachedAuth | null {
+  try {
+    const cachePath = getCachePath(ship);
+    if (!fs.existsSync(cachePath)) return null;
+    
+    const data: CachedAuth = JSON.parse(fs.readFileSync(cachePath, "utf-8"));
+    if (data.url && data.ship && data.cookie) {
+      return data;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cache cookie for future use
+ */
+function cacheCookie(url: string, ship: string, cookie: string): void {
+  try {
+    fs.mkdirSync(CACHE_DIR, { recursive: true, mode: 0o700 });
+    const cachePath = getCachePath(ship);
+    const data: CachedAuth = {
+      url,
+      ship: ship.replace(/^~/, ""),
+      cookie,
+      cachedAt: Date.now(),
+    };
+    fs.writeFileSync(cachePath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  } catch {
+    // Cache write failure is non-fatal
+  }
+}
+
+/**
+ * Parse ship name from auth cookie.
+ * Cookie format: urbauth-~ship=0v...
+ */
+function parseShipFromCookie(cookie: string): string | null {
+  const match = cookie.match(/urbauth-~?([a-z-]+)=/);
+  return match ? match[1] : null;
+}
 
 /**
  * Try to read Tlon credentials from OpenClaw config
@@ -38,15 +153,22 @@ function getConfigFromOpenClaw(): UrbitConfig | null {
       const parsed = JSON.parse(raw);
 
       const tlon = parsed?.channels?.tlon;
-      if (tlon?.url && tlon?.ship && tlon?.code) {
-        // Skip if values look like unexpanded env var templates
-        if (tlon.url.includes("${") || tlon.ship.includes("${") || tlon.code.includes("${")) {
-          continue;
+      if (tlon?.url && (tlon?.code || tlon?.cookie)) {
+        if (tlon.url.includes("${")) continue;
+        if (tlon.code?.includes("${") || tlon.cookie?.includes("${")) continue;
+        if (tlon.ship?.includes("${")) continue;
+
+        let ship = tlon.ship?.replace(/^~/, "");
+        if (!ship && tlon.cookie) {
+          ship = parseShipFromCookie(tlon.cookie);
         }
+        if (!ship) continue;
+
         return {
           url: tlon.url,
-          ship: tlon.ship.replace(/^~/, ""),
-          code: tlon.code,
+          ship,
+          code: tlon.code || "",
+          cookie: tlon.cookie,
         };
       }
     } catch {
@@ -61,53 +183,89 @@ function getConfigFromOpenClaw(): UrbitConfig | null {
  * Get config from ship file or environment
  *
  * Priority:
- * 1. TLON_CONFIG_FILE env var (direct path to config file, set by --config)
- * 2. URBIT or TLON env vars (URL + SHIP + CODE, all three required)
- * 3. TLON_SHIP + TLON_SKILL_DIR (loads ships/<ship>.json)
- * 4. OpenClaw config (~/.openclaw/openclaw.yaml)
+ * 1. TLON_CONFIG_FILE env var (direct path to config file)
+ * 2. Cookie-based auth (URL + COOKIE, ship derived from cookie)
+ * 3. Code-based auth (URL + SHIP + CODE)
+ * 4. Ship flag with cache lookup (SHIP only, uses cached url+cookie)
+ * 5. TLON_SHIP + TLON_SKILL_DIR (loads ships/<ship>.json)
+ * 6. OpenClaw config (~/.openclaw/openclaw.yaml)
+ * 7. Cached ships (if exactly one cached, use it)
  */
 export function getConfig(): UrbitConfig {
   if (cachedConfig) return cachedConfig;
 
-  // Option 1: Direct config file path (--config flag or TLON_CONFIG_FILE)
   const configFile = process.env.TLON_CONFIG_FILE;
   if (configFile) {
     cachedConfig = loadConfigFile(configFile);
     return cachedConfig;
   }
 
-  // Option 2: Explicit env vars (--url/--ship/--code flags or URBIT_*/TLON_* env vars)
-  // All three must be present
   const url = process.env.URBIT_URL || process.env.TLON_URL;
-  const ship = process.env.URBIT_SHIP || process.env.TLON_SHIP;
+  const shipEnv = process.env.URBIT_SHIP || process.env.TLON_SHIP;
+  const cookie = process.env.URBIT_COOKIE || process.env.TLON_COOKIE;
   const code = process.env.URBIT_CODE || process.env.TLON_CODE;
 
-  if (url && ship && code) {
-    cachedConfig = { url, ship: ship.replace(/^~/, ""), code };
+  // Track what user provided for later warnings
+  userProvidedUrl = !!url;
+  userProvidedCode = !!code;
+
+  // Cookie-based auth (URL + COOKIE)
+  if (url && cookie) {
+    const ship = shipEnv?.replace(/^~/, "") || parseShipFromCookie(cookie);
+    if (ship) {
+      cachedConfig = { url, ship, code: code || "", cookie };
+      return cachedConfig;
+    }
+  }
+
+  // Code-based auth (URL + SHIP + CODE)
+  if (url && shipEnv && code) {
+    cachedConfig = { url, ship: shipEnv.replace(/^~/, ""), code };
     return cachedConfig;
   }
 
-  // Option 3: Ship name + skill dir (loads ships/<ship>.json)
-  const shipName = process.env.TLON_SHIP;
+  // Ship-only with cache lookup (--ship ~foo uses cached entry)
+  if (shipEnv && !url && !code && !cookie) {
+    const cached = getCachedEntry(shipEnv.replace(/^~/, ""));
+    if (cached) {
+      cachedConfig = { url: cached.url, ship: cached.ship, code: "", cookie: cached.cookie };
+      return cachedConfig;
+    }
+  }
+
+  // Ship + skill dir (loads ships/<ship>.json)
   const skillDir = process.env.TLON_SKILL_DIR;
-  if (shipName && skillDir) {
-    const shipFile = path.join(skillDir, "ships", `${shipName.replace(/^~/, "")}.json`);
-    cachedConfig = loadConfigFile(shipFile);
+  if (shipEnv && skillDir) {
+    cachedConfig = loadConfigFile(path.join(skillDir, "ships", `${shipEnv.replace(/^~/, "")}.json`));
     return cachedConfig;
   }
 
-  // Option 4: OpenClaw config
+  // OpenClaw config
   const openclawConfig = getConfigFromOpenClaw();
   if (openclawConfig) {
     cachedConfig = openclawConfig;
     return cachedConfig;
   }
 
+  // Cached ships fallback
+  const cachedShips = getCachedShips();
+  if (cachedShips.length === 1) {
+    const entry = cachedShips[0];
+    cachedConfig = { url: entry.url, ship: entry.ship, code: "", cookie: entry.cookie };
+    return cachedConfig;
+  }
+  if (cachedShips.length > 1) {
+    const shipList = cachedShips.map(s => `  ~${s.ship}`).join("\n");
+    throw new Error(
+      `Multiple cached ships found. Specify which with --ship:\n${shipList}`
+    );
+  }
+
   throw new Error(
     "Missing Urbit config. Either:\n" +
-      "  - Use CLI flags: --config <file>, or --url + --ship + --code, or\n" +
-      "  - Set TLON_CONFIG_FILE, or TLON_SHIP + TLON_SKILL_DIR, or\n" +
-      "  - Set URBIT_URL/TLON_URL, URBIT_SHIP/TLON_SHIP, and URBIT_CODE/TLON_CODE env vars, or\n" +
+      "  - Use CLI flags: --config <file>, or --url + --cookie, or --url + --ship + --code\n" +
+      "  - Use --ship with a previously cached ship\n" +
+      "  - Set URBIT_URL + URBIT_COOKIE, or URBIT_URL + URBIT_SHIP + URBIT_CODE\n" +
       "  - Configure Tlon channel in OpenClaw (~/.openclaw/openclaw.yaml)"
   );
 }
@@ -121,14 +279,27 @@ function loadConfigFile(filePath: string): UrbitConfig {
     const content = fs.readFileSync(filePath, "utf-8");
     const data = JSON.parse(content);
 
-    if (!data.url || !data.ship || !data.code) {
-      throw new Error(`Invalid config: must have url, ship, and code`);
+    if (!data.url) {
+      throw new Error(`Invalid config: must have url`);
+    }
+
+    if (!data.code && !data.cookie) {
+      throw new Error(`Invalid config: must have code or cookie`);
+    }
+
+    let ship = data.ship?.replace(/^~/, "");
+    if (!ship && data.cookie) {
+      ship = parseShipFromCookie(data.cookie);
+    }
+    if (!ship) {
+      throw new Error(`Invalid config: must have ship (or cookie with ship in name)`);
     }
 
     return {
       url: data.url,
-      ship: data.ship.replace(/^~/, ""),
-      code: data.code,
+      ship,
+      code: data.code || "",
+      cookie: data.cookie,
     };
   } catch (err: any) {
     if (err.message.includes("Invalid config") || err.message.includes("not found")) {
@@ -146,35 +317,19 @@ async function setupSubscriptions(subs: Array<'groups' | 'channels' | 'chat' | '
   if (subscribed) return;
 
   if (subs.includes('groups')) {
-    // groups mutations (createGroup, deleteGroup, updateGroupMeta, etc.)
-    await subscribe(
-      { app: 'groups', path: '/v1/groups' },
-      () => {}
-    );
+    await subscribe({ app: 'groups', path: '/v1/groups' }, () => {});
   }
 
   if (subs.includes('channels')) {
-    // channel mutations (createChannel, updateChannel, deleteChannel, etc.)
-    await subscribe(
-      { app: 'channels', path: '/v2' },
-      () => {}
-    );
+    await subscribe({ app: 'channels', path: '/v2' }, () => {});
   }
 
   if (subs.includes('chat')) {
-    // DM mutations (updateDMMeta)
-    await subscribe(
-      { app: 'chat', path: '/' },
-      () => {}
-    );
+    await subscribe({ app: 'chat', path: '/' }, () => {});
   }
 
   if (subs.includes('lanyard')) {
-    // lanyard/attestation mutations (phone verify, twitter attestation, etc.)
-    await subscribe(
-      { app: 'lanyard', path: '/v1/records' },
-      () => {}
-    );
+    await subscribe({ app: 'lanyard', path: '/v1/records' }, () => {});
   }
 
   subscribed = true;
@@ -186,15 +341,66 @@ async function setupSubscriptions(subs: Array<'groups' | 'channels' | 'chat' | '
  */
 export async function ensureClient(subs: Array<'groups' | 'channels' | 'chat' | 'lanyard'> = []): Promise<UrbitConfig> {
   const cfg = getConfig();
+  
   if (!initialized) {
-    await configureClient({
-      shipName: cfg.ship,
-      shipUrl: cfg.url,
-      getCode: async () => cfg.code
-    });
+    // Determine cookie to use: explicit > cached > none (use code)
+    let cookieToUse = cfg.cookie || getCachedCookie(cfg.url, cfg.ship);
+    let usedCachedCookie = !cfg.cookie && !!cookieToUse;
+    let didFreshAuth = false;
+    
+    if (cookieToUse) {
+      // Cookie-based auth
+      const urbit = new Urbit(cfg.url);
+      urbit.cookie = cookieToUse;
+      urbit.nodeId = preSig(cfg.ship);
+      
+      await configureClient({
+        shipName: cfg.ship,
+        shipUrl: cfg.url,
+        client: urbit,
+        getCode: cfg.code ? async () => cfg.code : undefined,
+      });
+      
+      // Warn if user passed credentials that weren't needed
+      if (usedCachedCookie && userProvidedCode) {
+        const cachedShips = getCachedShips();
+        if (cachedShips.length === 1) {
+          console.error(`Note: Using cached credentials for ~${cfg.ship}. You can just run: tlon <command>`);
+        } else {
+          console.error(`Note: Using cached credentials for ~${cfg.ship}. You can just run: tlon --ship ~${cfg.ship} <command>`);
+        }
+      }
+    } else if (cfg.code) {
+      // Code-based auth (first time)
+      await configureClient({
+        shipName: cfg.ship,
+        shipUrl: cfg.url,
+        getCode: async () => cfg.code,
+      });
+      didFreshAuth = true;
+    } else {
+      throw new Error("No cookie or code available for authentication");
+    }
+    
+    // Cache the cookie for future invocations
+    if (client.cookie) {
+      cacheCookie(cfg.url, cfg.ship, client.cookie);
+      
+      // Notify on first auth that credentials are now cached
+      if (didFreshAuth) {
+        const cachedShips = getCachedShips();
+        if (cachedShips.length === 1) {
+          console.error(`Note: Credentials cached for ~${cfg.ship}. Next time just run: tlon <command>`);
+        } else {
+          console.error(`Note: Credentials cached for ~${cfg.ship}. Next time run: tlon --ship ~${cfg.ship} <command>`);
+        }
+      }
+    }
+    
     await setupSubscriptions(subs);
     initialized = true;
   }
+  
   return cfg;
 }
 

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -42,29 +42,33 @@ Commands:
   upload       Upload an image from URL to Tlon storage
 
 Credential Options (override defaults):
-  --config <file>   Path to JSON config file with url, ship, code
+  --config <file>   Path to JSON config file with url + cookie or url + ship + code
   --url <url>       Ship URL (e.g., https://your-ship.tlon.network)
-  --ship <~name>    Ship name (e.g., ~sampel-palnet)
+  --ship <~name>    Ship name (uses cached credentials if available)
   --code <code>     Access code (e.g., sampel-ticlyt-migfun-falmel)
+  --cookie <cookie> Pre-authenticated cookie (ship is parsed from cookie name)
 
 Other Options:
   --help, -h     Show this help
   --version, -v  Show version
 
 Config Resolution (first match wins):
-  1. CLI flags (--url, --ship, --code or --config)
+  1. CLI flags (--config, or --url + --cookie, or --url + --ship + --code)
   2. TLON_CONFIG_FILE env var
-  3. TLON_SHIP + TLON_SKILL_DIR (loads ships/<ship>.json)
-  4. URBIT_URL/TLON_URL, URBIT_SHIP/TLON_SHIP, URBIT_CODE/TLON_CODE env vars
-  5. OpenClaw config (~/.openclaw/openclaw.yaml)
+  3. URBIT_URL + URBIT_COOKIE (ship derived from cookie)
+  4. URBIT_URL + URBIT_SHIP + URBIT_CODE
+  5. --ship with cached credentials (no url/code needed)
+  6. TLON_SHIP + TLON_SKILL_DIR (loads ships/<ship>.json)
+  7. OpenClaw config (~/.openclaw/openclaw.yaml)
+  8. Cached ships (auto-select if only one)
 
 Examples:
   tlon contacts list
   tlon messages dm ~sampel-palnet --limit 10
   tlon groups create "My Group" --description "A cool group"
   tlon posts react chat/~host/channel 170.141.184... 👍
-  tlon --ship ~zod contacts self
   tlon --config ~/ships/zod.json contacts self
+  tlon --url https://zod.tlon.network --cookie "urbauth-~zod=0v..." contacts self
   tlon --url https://zod.tlon.network --ship ~zod --code abcd-efgh-ijkl-mnop contacts self
 `);
 }
@@ -76,6 +80,7 @@ async function main() {
   let urlOverride: string | null = null;
   let shipOverride: string | null = null;
   let codeOverride: string | null = null;
+  let cookieOverride: string | null = null;
   let configOverride: string | null = null;
   const args: string[] = [];
 
@@ -126,28 +131,47 @@ async function main() {
       continue;
     }
 
+    // --cookie
+    if (arg === "--cookie" && rawArgs[i + 1]) {
+      cookieOverride = rawArgs[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--cookie=")) {
+      cookieOverride = arg.split("=", 2)[1] || "";
+      continue;
+    }
+
     args.push(arg);
   }
 
   // Apply credential overrides
-  // Priority: --config > (--url + --ship + --code) > --ship alone
   if (configOverride) {
-    // --config sets TLON_CONFIG_FILE for direct file loading
     process.env.TLON_CONFIG_FILE = configOverride;
+  } else if (urlOverride && cookieOverride) {
+    // URL + cookie: ship derived from cookie (or explicit --ship)
+    process.env.URBIT_URL = urlOverride;
+    process.env.URBIT_COOKIE = cookieOverride;
+    if (shipOverride) {
+      process.env.URBIT_SHIP = shipOverride.replace(/^~/, "");
+    }
+    if (codeOverride) {
+      process.env.URBIT_CODE = codeOverride;
+    }
   } else if (urlOverride && shipOverride && codeOverride) {
-    // All three flags: set URBIT_* env vars for direct use
+    // URL + ship + code: traditional auth
     process.env.URBIT_URL = urlOverride;
     process.env.URBIT_SHIP = shipOverride.replace(/^~/, "");
     process.env.URBIT_CODE = codeOverride;
-  } else if (shipOverride && !urlOverride && !codeOverride) {
-    // Only --ship: set TLON_SHIP for ships/ directory lookup
+  } else if (shipOverride && !urlOverride && !codeOverride && !cookieOverride) {
+    // Only --ship: set TLON_SHIP for cache lookup or ships/ directory
     process.env.TLON_SHIP = shipOverride.replace(/^~/, "");
-  } else if (urlOverride || codeOverride) {
-    // Partial flags (--url or --code without all three) - set what we have
-    // This allows merging with existing env vars
+  } else if (urlOverride || codeOverride || cookieOverride) {
+    // Partial flags - set what we have (allows merging with env vars)
     if (urlOverride) process.env.URBIT_URL = urlOverride;
     if (shipOverride) process.env.URBIT_SHIP = shipOverride.replace(/^~/, "");
     if (codeOverride) process.env.URBIT_CODE = codeOverride;
+    if (cookieOverride) process.env.URBIT_COOKIE = cookieOverride;
   }
 
   const command = args[0];
@@ -163,7 +187,6 @@ async function main() {
   }
 
   // Rewrite process.argv so scripts see their args correctly
-  // Scripts expect: [node, script, subcommand, ...args]
   const scriptArgs = args.slice(1);
   process.argv = ["tlon", command, ...scriptArgs];
 


### PR DESCRIPTION
## Summary

Adds cookie-based authentication with automatic caching for faster CLI invocations.

**Based on #56** (selective subscriptions), without the logout cleanup.

## Features

### Cookie Auth
- New `--cookie` CLI flag and `URBIT_COOKIE` env var
- Ship name parsed from cookie (`urbauth-~ship=...`), so `--ship` is optional
- Simpler auth: just `--url + --cookie` instead of `--url + --ship + --code`

### Cookie Caching
- Cookies cached to `~/.tlon/cache/<ship>.json` after successful auth
- Subsequent invocations use cached cookie automatically (skips login)
- Cache is URL-specific (won't use cookie for wrong host)
- Secure file permissions (0600)

### Cache as Config Fallback
- If only one cached ship exists, auto-select it (no config needed at all)
- If multiple cached ships, error with list: `--ship ~zod` or `--ship ~bus`
- `--ship ~foo` now works with just cached credentials (no url/code required)
- Helpful reminders when you pass credentials that aren't needed

## Config Resolution Priority

1. CLI flags (`--config`, or `--url + --cookie`, or `--url + --ship + --code`)
2. `TLON_CONFIG_FILE` env var
3. `URBIT_URL + URBIT_COOKIE`
4. `URBIT_URL + URBIT_SHIP + URBIT_CODE`
5. `--ship` with cached credentials
6. `TLON_SHIP + TLON_SKILL_DIR`
7. OpenClaw config
8. Cached ships (auto-select if only one)

## Usage

```bash
# First run - authenticates with code, caches cookie
tlon --url https://zod.tlon.network --ship ~zod --code abcd-efgh contacts self
# Note: Credentials cached for ~zod. Next time just run: tlon <command>

# Subsequent runs - uses cached cookie automatically (no flags needed!)
tlon contacts self

# Switch between cached ships
tlon --ship ~zod contacts self
tlon --ship ~bus contacts self

# Or provide cookie directly
tlon --url https://zod.tlon.network --cookie "urbauth-~zod=0v..." contacts self

# Clear cache if needed
rm ~/.tlon/cache/*.json
```