### PR TITLE
chore: release v0.2.0

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-arm64",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "Tlon skill binary for macOS ARM64",
   "os": [
     "darwin"

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-x64",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "Tlon skill binary for macOS x64",
   "os": [
     "darwin"

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-linux-arm64",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "Tlon skill binary for Linux arm64",
   "os": [
     "linux"

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-linux-x64",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "Tlon skill binary for Linux x64",
   "os": [
     "linux"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "Tlon/Urbit skill for OpenClaw agents",
   "type": "module",
   "bin": {
@@ -21,10 +21,10 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "optionalDependencies": {
-    "@tloncorp/tlon-skill-darwin-arm64": "0.1.12",
-    "@tloncorp/tlon-skill-darwin-x64": "0.1.12",
-    "@tloncorp/tlon-skill-linux-x64": "0.1.12",
-    "@tloncorp/tlon-skill-linux-arm64": "0.1.12"
+    "@tloncorp/tlon-skill-darwin-arm64": "0.2.0",
+    "@tloncorp/tlon-skill-darwin-x64": "0.2.0",
+    "@tloncorp/tlon-skill-linux-x64": "0.2.0",
+    "@tloncorp/tlon-skill-linux-arm64": "0.2.0"
   },
   "devDependencies": {
     "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#main",


### PR DESCRIPTION
## Release v0.2.0

### ✨ New Features

#### Cookie-based Authentication with Caching (#57)
- New `--cookie` CLI flag and `URBIT_COOKIE` env var
- Ship name parsed from cookie (`urbauth-~ship=...`)
- Automatic cookie caching to `~/.tlon/cache/<ship>.json`
- Auto-select cached ship if only one exists
- `--ship ~foo` works with just cached credentials
- Helpful reminders when credentials aren't needed

#### Channel Hooks Command (#54, #55)
- New `tlon hooks` command for managing channel hooks
- Subcommands: `list`, `add`, `edit`, `delete`, `order`, `config`, `cron`, `rest`
- Initialize hooks with templates: `tlon hooks init <channel> <type>`
- Improved hook templates with concrete, working examples
- Better documentation with pitfalls section and bowl access patterns

#### Expose Command for Clearweb Publishing (#44)
- New `tlon expose` command for managing public content
- Subcommands: `list`, `show`, `hide`, `check`, `url`
- Expose channels and posts to the clearweb

#### Nicknames Support (#50, #53)
- Show nicknames for group members in `groups info`
- Nicknames shown in activity, messages, and channels

### ⚡ Performance

#### Selective Subscriptions (#56)
- Only subscribe to needed Urbit channels per command
- Reduces connection overhead for read-only operations
- Consolidated `ensureClient` calls to once per command

### 📝 Documentation

- Updated SKILL.md and README with all new features
- Cookie caching workflow examples
- Comprehensive hooks documentation with examples

---

**Full Changelog**: https://github.com/tloncorp/tlon-skill/compare/v0.1.12...release/v0.2.0