### PR TITLE
fix: publish workflow condition

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,8 +56,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    # Only run on tags pushed directly to master, or manual workflow_dispatch
-    if: (startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push' && github.ref_name == 'master') || github.event.inputs.dry_run == 'false'
+    # Only run on version tags, or manual workflow_dispatch with dry_run=false
+    if: (startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push') || github.event.inputs.dry_run == 'false'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
When pushing a tag like `v0.2.0`, `github.ref_name` is the tag name (e.g. `v0.2.0`), not `master`, so the publish job was always skipped.

The tag filter on the trigger (`push: tags: - 'v*'`) already ensures only version tags run this workflow, so the extra `github.ref_name == 'master'` check was both broken and redundant.

Fixes the skipped publish in https://github.com/tloncorp/tlon-skill/actions/runs/22678060110