### PR TITLE
fix: pin api-beta to S3 endpoint fix + bump to v0.2.1

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-arm64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Tlon skill binary for macOS ARM64",
   "os": [
     "darwin"

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-darwin-x64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Tlon skill binary for macOS x64",
   "os": [
     "darwin"

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-linux-arm64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Tlon skill binary for Linux arm64",
   "os": [
     "linux"

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill-linux-x64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Tlon skill binary for Linux x64",
   "os": [
     "linux"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/tlon-skill",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Tlon/Urbit skill for OpenClaw agents",
   "type": "module",
   "bin": {
@@ -21,10 +21,10 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "optionalDependencies": {
-    "@tloncorp/tlon-skill-darwin-arm64": "0.2.0",
-    "@tloncorp/tlon-skill-darwin-x64": "0.2.0",
-    "@tloncorp/tlon-skill-linux-x64": "0.2.0",
-    "@tloncorp/tlon-skill-linux-arm64": "0.2.0"
+    "@tloncorp/tlon-skill-darwin-arm64": "0.2.1",
+    "@tloncorp/tlon-skill-darwin-x64": "0.2.1",
+    "@tloncorp/tlon-skill-linux-x64": "0.2.1",
+    "@tloncorp/tlon-skill-linux-arm64": "0.2.1"
   },
   "devDependencies": {
     "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#c5eb1720d94435b62503605acb294ef42a5440b3",


### PR DESCRIPTION
## Changes

1. **Pin @tloncorp/api to S3 fix commit** (c5eb172)
   - Fixes upload failures for self-hosted ships with custom S3 credentials
   - Error was: `Unable to parse "https//..." as a whatwg URL` (missing colon)
   - See: https://github.com/tloncorp/api-beta/pull/9

2. **Bump version to 0.2.1**

## Testing

Tested locally with DigitalOcean Spaces - uploads now work correctly:
```
./bin/tlon --ship nocsyx-lassul upload https://httpbin.org/image/png
https://nyc3.digitaloceanspaces.com/hmillerdev/nocsyx-lassul/2026.3.4..19.19.27..1168.72b0.20c4.9ba5-upload.png
```