### PR TITLE
Add bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -34,3 +34,7 @@ jobs:
           git tag "v${{ inputs.version }}"
           git push
           git push --tags
+
+  publish:
+    needs: bump
+    uses: ./.github/workflows/publish.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_call: {}
   workflow_dispatch:
     inputs:
       dry_run:
@@ -56,8 +57,11 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    # Only run on version tags, or manual workflow_dispatch with dry_run=false
-    if: (startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push') || github.event.inputs.dry_run == 'false'
+    # Run on: version tag push, workflow_call from bump, or manual dispatch with dry_run=false
+    if: >-
+      (startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push') ||
+      github.event_name == 'workflow_call' ||
+      github.event.inputs.dry_run == 'false'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds a manual dispatch GitHub Action to bump versions across all package.json files, commit, tag, and push — which then triggers the existing publish workflow.

**Usage:** Actions → Bump Version → Run workflow → enter version (e.g. `0.4.0`)