### PR TITLE
docs: remove group DM (club) examples from SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -134,11 +134,10 @@ tlon activity unreads               # Unread counts per channel
 
 ### Channels
 
-List and manage channels. DMs and group DMs show nicknames when available.
+List and manage channels. DMs show nicknames when available.
 
 ```bash
 tlon channels dms                                          # List DM contacts (with nicknames)
-tlon channels group-dms                                    # List group DMs (clubs, with nicknames)
 tlon channels groups                                       # List subscribed groups
 tlon channels all                                          # List everything
 tlon channels info chat/~host/slug                         # Get channel details
@@ -287,7 +286,7 @@ finding surrounding conversation when you have a post from search or activity.
 For DMs, use the ship name as the channel: `tlon messages context ~sampel 170.141...`
 
 The `post` command fetches a single post with its replies/thread. For DM posts,
-pass `--author ~ship` (required for DM/club lookups).
+pass `--author ~ship` (required for DM lookups).
 
 **Tip:** Use `search` to find a message, then `context` with its ID to see the surrounding conversation.
 
@@ -296,10 +295,6 @@ pass `--author ~ship` (required for DM/club lookups).
 Manage direct messages.
 
 ```bash
-# Group DMs (clubs)
-tlon dms send <club-id> "hello"                          # Send to group DM
-tlon dms reply <club-id> ~author/170.141... "reply"      # Reply in group DM
-
 # Management
 tlon dms react ~sampel ~author/170.141... "👍"           # React to a DM
 tlon dms unreact ~sampel ~author/170.141...              # Remove reaction

--- a/references/hooks.md
+++ b/references/hooks.md
@@ -118,7 +118,6 @@ Hooks can trigger actions on other agents:
       [%groups =action:g]       :: group actions (ban, kick, etc)
       [%activity =action:a]     :: activity actions
       [%dm =action:dm:ch]       :: DM actions
-      [%club =action:club:ch]   :: group DM actions
       [%contacts =action:co]    :: contact actions
       [%wait waiting-hook]      :: schedule delayed execution
   ==

--- a/references/urbit-api.md
+++ b/references/urbit-api.md
@@ -68,16 +68,13 @@ interface ContactBookProfile {
 
 ### Scry Paths
 - `/dm` - List of DM ship names (string[])
-- `/clubs` - Group DMs (Clubs)
 - `/blocked` - Blocked ships
 - `/v3/dm/~ship/writs/newest/{count}/light` - DM message history (light = no replies)
 - `/v3/dm/~ship/writs/newest/{count}/heavy` - DM message history (heavy = with replies)
-- `/v3/club/{clubId}/writs/newest/{count}/light` - Group DM message history
 - `/v2/dm/~ship/writs/writ/id/{author}/{postId}` - Single DM post with replies
 
 ### Poke Marks
 - `chat-dm-action-1` - Send DM
-- `chat-club-action-1` - Group DM operations
 - `chat-remark-action` - Mark read
 
 ## Groups Agent


### PR DESCRIPTION
Remove the group DM (club) send/reply examples from the DMs section of SKILL.md.