### PR TITLE
Improve channel CLI help and aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ tlon --url https://bot.tlon.network --cookie "urbauth-~bot=0v..." contacts self
 # List your groups
 tlon channels groups
 
+# Create a group channel
+# (preferred alias; tlon groups add-channel still works)
+tlon channels create ~host/group-slug "Projects" --kind chat
+
+# Rename a channel
+tlon channels rename chat/~host/project-updates "Team Updates"
+
 # Get recent mentions
 tlon activity mentions --limit 10
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -150,6 +150,8 @@ tlon channels dms                                          # List DM contacts (w
 tlon channels groups                                       # List subscribed groups
 tlon channels all                                          # List everything
 tlon channels info chat/~host/slug                         # Get channel details
+tlon channels create ~host/slug "Projects" --kind chat     # Create a group channel
+tlon channels rename chat/~host/slug "New Title"           # Rename a channel
 tlon channels update chat/~host/slug --title "New Title"   # Update metadata
 tlon channels delete chat/~host/slug                       # Delete a channel
 
@@ -160,6 +162,14 @@ tlon channels del-writers chat/~host/slug member           # Remove write access
 # Readers (who can view - requires group flag)
 tlon channels add-readers ~host/group chat/~host/slug admin    # Restrict viewing
 tlon channels del-readers ~host/group chat/~host/slug admin    # Open viewing
+```
+
+Help works for both the command and subcommands:
+
+```bash
+tlon channels --help
+tlon channels create --help
+tlon channels rename --help
 ```
 
 Notes on permissions:
@@ -230,6 +240,19 @@ Roles vs Admin:
 
 # Channels
 tlon groups add-channel ~host/slug "Name" [--kind chat|diary|heap]
+```
+
+`tlon groups add-channel` remains supported, but for agent/tool use prefer the more discoverable channel-centric form:
+
+```bash
+tlon channels create ~host/slug "Projects" --kind chat
+```
+
+Help works here too:
+
+```bash
+tlon groups --help
+tlon groups add-channel --help
 ```
 
 Group format: `~host-ship/group-slug`

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -8,6 +8,8 @@
  *   npx ts-node channels.ts groups     # List subscribed groups
  *   npx ts-node channels.ts all        # List all channels
  *   npx ts-node channels.ts info <nest>   # Get channel info
+ *   npx ts-node channels.ts create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]
+ *   npx ts-node channels.ts rename <nest> "New Title"
  *   npx ts-node channels.ts update <nest> --title "..." [--description "..."]
  *   npx ts-node channels.ts delete <nest> # Delete a channel (must be group admin)
  *   npx ts-node channels.ts add-writers <nest> <role1> [role2...]
@@ -18,6 +20,7 @@
 
 import {
   addChannelWriters as apiAddWriters,
+  createChannel,
   deleteChannel,
   getGroups,
   getInitData,
@@ -27,6 +30,58 @@ import {
 } from "@tloncorp/api";
 import type { Channel as ApiChannel, Group as ApiGroup } from "@tloncorp/api";
 import { ensureClient, getCurrentShip } from "./api-client";
+import { getOption, looksLikePositionalChannelKind, wantsHelp } from "./cli-utils";
+
+function generateChannelSlug(): string {
+  const chars = "abcdefghijklmnopqrstuvwxyz";
+  const alphanumeric = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let slug = chars[Math.floor(Math.random() * chars.length)];
+  for (let i = 0; i < 7; i++) {
+    slug += alphanumeric[Math.floor(Math.random() * alphanumeric.length)];
+  }
+  return slug;
+}
+
+const CHANNELS_HELP = `Usage: channels.ts <command>
+
+Commands:
+  dms
+  group-dms
+  groups
+  all
+  info <nest>
+  create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]
+  update <nest> --title "..." [--description "..."]
+  rename <nest> "New Title"
+  delete <nest>
+  add-writers <nest> <role1> [role2...]
+  del-writers <nest> <role1> [role2...]
+  add-readers <group-flag> <nest> <role1> [role2...]
+  del-readers <group-flag> <nest> <role1> [role2...]
+
+Examples:
+  channels.ts create ~host/group-slug "Projects" --kind chat
+  channels.ts rename chat/~host/project-updates "Team Updates"`;
+
+const CHANNELS_COMMAND_HELP: Record<string, string> = {
+  dms: `Usage: channels.ts dms`,
+  "group-dms": `Usage: channels.ts group-dms`,
+  groups: `Usage: channels.ts groups`,
+  all: `Usage: channels.ts all`,
+  info: `Usage: channels.ts info <nest>\nExample: channels.ts info chat/~host/slug`,
+  create: `Usage: channels.ts create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]\nExample: channels.ts create ~host/group-slug "Projects" --kind chat`,
+  update: `Usage: channels.ts update <nest> --title "..." [--description "..."]\nExample: channels.ts update chat/~host/slug --title "New Title"`,
+  rename: `Usage: channels.ts rename <nest> "New Title"\nExample: channels.ts rename chat/~host/slug "Project Updates"`,
+  delete: `Usage: channels.ts delete <nest>\nExample: channels.ts delete chat/~host/slug`,
+  "add-writers": `Usage: channels.ts add-writers <nest> <role1> [role2...]\nExample: channels.ts add-writers chat/~host/slug admin`,
+  "del-writers": `Usage: channels.ts del-writers <nest> <role1> [role2...]\nExample: channels.ts del-writers chat/~host/slug member`,
+  "add-readers": `Usage: channels.ts add-readers <group-flag> <nest> <role1> [role2...]\nExample: channels.ts add-readers ~host/group-slug chat/~host/slug admin`,
+  "del-readers": `Usage: channels.ts del-readers <group-flag> <nest> <role1> [role2...]\nExample: channels.ts del-readers ~host/group-slug chat/~host/slug admin`,
+};
+
+function printChannelsHelp(command?: string) {
+  console.log(command ? CHANNELS_COMMAND_HELP[command] ?? CHANNELS_HELP : CHANNELS_HELP);
+}
 
 // Get DMs
 async function getDms() {
@@ -163,6 +218,37 @@ async function getChannelInfo(nest: string) {
     zone: findChannelSectionId(group, channel.id),
     readers: readerRoles,
   };
+}
+
+async function createChannelInGroup(
+  groupId: string,
+  title: string,
+  kind: "chat" | "diary" | "heap" = "chat",
+  description = ""
+) {
+  const ship = await getCurrentShip();
+  const name = generateChannelSlug();
+  const nest = `${kind}/${ship}/${name}`;
+
+  console.log(`Adding channel "${title}" to group ${groupId}...`);
+
+  await createChannel({
+    id: nest,
+    kind,
+    group: groupId,
+    name,
+    title,
+    description,
+    meta: null,
+    readers: [],
+    writers: [],
+  });
+
+  console.log(`✅ Channel created!`);
+  console.log(`   Nest: ${nest}`);
+  console.log(`   Title: ${title}`);
+  console.log(`   Group: ${groupId}`);
+  return nest;
 }
 
 // Update channel metadata
@@ -303,8 +389,18 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
+  if (!command || command === "--help" || command === "-h") {
+    printChannelsHelp();
+    process.exit(0);
+  }
+
+  if (wantsHelp(args.slice(1))) {
+    printChannelsHelp(command);
+    process.exit(0);
+  }
+
   try {
-    await ensureClient(['channels']);
+    await ensureClient(["channels"]);
     switch (command) {
       case "dms": {
         const dms = await getDms();
@@ -333,30 +429,44 @@ async function main() {
       case "info": {
         const nest = args[1];
         if (!nest) {
-          console.error("Usage: channels.ts info <nest>");
-          console.error("Example: channels.ts info chat/~ship/channel-name");
+          console.error(CHANNELS_COMMAND_HELP.info);
           process.exit(1);
         }
         await getChannelInfo(nest);
         break;
       }
 
+      case "create": {
+        const groupId = args[1];
+        const title = args[2];
+        if (!groupId || !title) {
+          console.error(CHANNELS_COMMAND_HELP.create);
+          process.exit(1);
+        }
+        if (looksLikePositionalChannelKind(args, 2)) {
+          console.error("Error: channel kind must be passed with --kind, not as a positional argument.");
+          console.error(CHANNELS_COMMAND_HELP.create);
+          process.exit(1);
+        }
+        const kind = (getOption(args, "kind") as "chat" | "diary" | "heap") || "chat";
+        const description = getOption(args, "description") || "";
+        await createChannelInGroup(groupId, title, kind, description);
+        break;
+      }
+
       case "update": {
         const nest = args[1];
         if (!nest) {
-          console.error("Usage: channels.ts update <nest> --title \"...\" [--description \"...\"]");
-          console.error("Example: channels.ts update chat/~ship/channel-name --title \"New Title\"");
+          console.error(CHANNELS_COMMAND_HELP.update);
           process.exit(1);
         }
 
-        // Parse options
-        const titleIdx = args.indexOf("--title");
-        const descriptionIdx = args.indexOf("--description");
-        const title = titleIdx !== -1 ? args[titleIdx + 1] : undefined;
-        const description = descriptionIdx !== -1 ? args[descriptionIdx + 1] : undefined;
+        const title = getOption(args, "title");
+        const description = getOption(args, "description");
 
         if (!title && !description) {
           console.error("Error: At least one of --title or --description is required");
+          console.error(CHANNELS_COMMAND_HELP.update);
           process.exit(1);
         }
 
@@ -364,11 +474,21 @@ async function main() {
         break;
       }
 
+      case "rename": {
+        const nest = args[1];
+        const title = args[2];
+        if (!nest || !title) {
+          console.error(CHANNELS_COMMAND_HELP.rename);
+          process.exit(1);
+        }
+        await updateChannelMeta(nest, { title });
+        break;
+      }
+
       case "delete": {
         const nest = args[1];
         if (!nest) {
-          console.error("Usage: channels.ts delete <nest>");
-          console.error("Example: channels.ts delete chat/~ship/channel-name");
+          console.error(CHANNELS_COMMAND_HELP.delete);
           process.exit(1);
         }
         await deleteChannelByNest(nest);
@@ -379,8 +499,7 @@ async function main() {
         const nest = args[1];
         const roles = args.slice(2);
         if (!nest || roles.length === 0) {
-          console.error("Usage: channels.ts add-writers <nest> <role1> [role2...]");
-          console.error("Example: channels.ts add-writers chat/~host/slug admin");
+          console.error(CHANNELS_COMMAND_HELP["add-writers"]);
           process.exit(1);
         }
         await addWriters(nest, roles);
@@ -391,8 +510,7 @@ async function main() {
         const nest = args[1];
         const roles = args.slice(2);
         if (!nest || roles.length === 0) {
-          console.error("Usage: channels.ts del-writers <nest> <role1> [role2...]");
-          console.error("Example: channels.ts del-writers chat/~host/slug member");
+          console.error(CHANNELS_COMMAND_HELP["del-writers"]);
           process.exit(1);
         }
         await removeWriters(nest, roles);
@@ -404,8 +522,7 @@ async function main() {
         const nest = args[2];
         const roles = args.slice(3);
         if (!groupFlag || !nest || roles.length === 0) {
-          console.error("Usage: channels.ts add-readers <group-flag> <nest> <role1> [role2...]");
-          console.error("Example: channels.ts add-readers ~host/group chat/~host/slug admin");
+          console.error(CHANNELS_COMMAND_HELP["add-readers"]);
           process.exit(1);
         }
         await addReaders(groupFlag, nest, roles);
@@ -417,8 +534,7 @@ async function main() {
         const nest = args[2];
         const roles = args.slice(3);
         if (!groupFlag || !nest || roles.length === 0) {
-          console.error("Usage: channels.ts del-readers <group-flag> <nest> <role1> [role2...]");
-          console.error("Example: channels.ts del-readers ~host/group chat/~host/slug admin");
+          console.error(CHANNELS_COMMAND_HELP["del-readers"]);
           process.exit(1);
         }
         await removeReaders(groupFlag, nest, roles);
@@ -426,23 +542,7 @@ async function main() {
       }
 
       default:
-        console.log(`Usage: channels.ts <command>
-
-Commands:
-  dms                List DMs
-  group-dms          List group DMs (clubs)
-  groups             List subscribed groups with their channels
-  all                List all channels
-  info <nest>        Get channel info
-  update <nest>      Update channel --title "..." [--description "..."]
-  delete <nest>      Delete a channel (must be group admin)
-
-Permissions:
-  add-writers <nest> <role1> [role2...]                     Add write access
-  del-writers <nest> <role1> [role2...]                     Remove write access
-  add-readers <group-flag> <nest> <role1> [role2...]        Restrict viewing
-  del-readers <group-flag> <nest> <role1> [role2...]        Open viewing
-`);
+        printChannelsHelp();
         process.exit(1);
     }
     process.exit(0);

--- a/scripts/cli-utils.test.ts
+++ b/scripts/cli-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { getOption, looksLikePositionalChannelKind, wantsHelp } from "./cli-utils";
+
+describe("cli-utils", () => {
+  describe("wantsHelp", () => {
+    it("detects long help flag", () => {
+      expect(wantsHelp(["add-channel", "--help"])).toBe(true);
+    });
+
+    it("detects short help flag", () => {
+      expect(wantsHelp(["update", "-h"])).toBe(true);
+    });
+
+    it("returns false when help is absent", () => {
+      expect(wantsHelp(["groups", "info", "~zod/test"])).toBe(false);
+    });
+  });
+
+  describe("looksLikePositionalChannelKind", () => {
+    it("detects channel kind passed positionally", () => {
+      const args = ["add-channel", "~zod/test", "chat", "Projects"];
+      expect(looksLikePositionalChannelKind(args, 2)).toBe(true);
+    });
+
+    it("does not flag valid --kind usage", () => {
+      const args = ["add-channel", "~zod/test", "Projects", "--kind", "chat"];
+      expect(looksLikePositionalChannelKind(args, 2)).toBe(false);
+      expect(getOption(args, "kind")).toBe("chat");
+    });
+
+    it("does not flag ordinary titles", () => {
+      const args = ["add-channel", "~zod/test", "Projects"];
+      expect(looksLikePositionalChannelKind(args, 2)).toBe(false);
+    });
+  });
+});

--- a/scripts/cli-utils.ts
+++ b/scripts/cli-utils.ts
@@ -25,3 +25,31 @@ export function getOption(args: string[], name: string): string | undefined {
 export function hasFlag(args: string[], name: string): boolean {
   return args.includes(`--${name}`);
 }
+
+/**
+ * Check if help was requested for a command/subcommand
+ */
+export function wantsHelp(args: string[]): boolean {
+  return args.includes("--help") || args.includes("-h");
+}
+
+export const CHANNEL_KINDS = ["chat", "diary", "heap"] as const;
+
+/**
+ * Detect the common mistake of passing channel kind positionally instead of via --kind.
+ * Example: groups add-channel <group> chat "Title"
+ */
+export function looksLikePositionalChannelKind(
+  args: string[],
+  titleIndex: number,
+  kindOptionName = "kind"
+): boolean {
+  const title = args[titleIndex];
+  const nextPositional = args[titleIndex + 1];
+  return (
+    !!title &&
+    CHANNEL_KINDS.includes(title as (typeof CHANNEL_KINDS)[number]) &&
+    !!nextPositional &&
+    !getOption(args, kindOptionName)
+  );
+}

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -54,7 +54,7 @@ import {
 } from "@tloncorp/api";
 import type { Group } from "@tloncorp/api";
 import { ensureClient, getCurrentShip, normalizeShip } from "./api-client";
-import { getOption } from "./cli-utils";
+import { getOption, looksLikePositionalChannelKind, wantsHelp } from "./cli-utils";
 
 // Generate a random short ID for the group
 function generateGroupSlug(): string {
@@ -66,6 +66,65 @@ function generateGroupSlug(): string {
     slug += alphanumeric[Math.floor(Math.random() * alphanumeric.length)];
   }
   return slug;
+}
+
+const GROUPS_HELP = `Usage: groups.ts <command>
+
+Commands:
+  list
+  create "Group Name" [--description "..."]
+  invite <group-id> <ship> [<ship2> ...]
+  info <group-id>
+  leave <group-id>
+  join <group-id>
+  delete <group-id>
+  update <group-id> --title "..." [--description "..."] [--image "..."] [--cover "..."]
+  kick <group-id> <ship> [<ship2> ...]
+  ban <group-id> <ship> [<ship2> ...]
+  unban <group-id> <ship> [<ship2> ...]
+  add-role <group-id> <role-id> --title "..." [--description "..."]
+  delete-role <group-id> <role-id>
+  update-role <group-id> <role-id> --title "..." [--description "..."]
+  assign-role <group-id> <role-id> <ship> [<ship2> ...]
+  remove-role <group-id> <role-id> <ship> [<ship2> ...]
+  set-privacy <group-id> <public|private|secret>
+  accept-join <group-id> <ship> [<ship2> ...]
+  reject-join <group-id> <ship> [<ship2> ...]
+  promote <group-id> <ship> [<ship2> ...]
+  demote <group-id> <ship> [<ship2> ...]
+  add-channel <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]
+
+Examples:
+  groups.ts info ~host/group-slug
+  groups.ts add-channel ~host/group-slug "Projects" --kind chat`;
+
+const GROUPS_COMMAND_HELP: Record<string, string> = {
+  list: `Usage: groups.ts list`,
+  create: `Usage: groups.ts create "Group Name" [--description "..."]\nExample: groups.ts create "Projects" --description "Shared work"`,
+  invite: `Usage: groups.ts invite <group-id> <ship> [<ship2> ...]\nExample: groups.ts invite ~host/group-slug ~nec ~bud`,
+  info: `Usage: groups.ts info <group-id>\nExample: groups.ts info ~host/group-slug`,
+  leave: `Usage: groups.ts leave <group-id>\nExample: groups.ts leave ~host/group-slug`,
+  join: `Usage: groups.ts join <group-id>\nExample: groups.ts join ~host/group-slug`,
+  delete: `Usage: groups.ts delete <group-id>\nExample: groups.ts delete ~host/group-slug`,
+  update: `Usage: groups.ts update <group-id> --title "..." [--description "..."] [--image "..."] [--cover "..."]\nExample: groups.ts update ~host/group-slug --title "New Title"`,
+  kick: `Usage: groups.ts kick <group-id> <ship> [<ship2> ...]\nExample: groups.ts kick ~host/group-slug ~nec`,
+  ban: `Usage: groups.ts ban <group-id> <ship> [<ship2> ...]\nExample: groups.ts ban ~host/group-slug ~nec`,
+  unban: `Usage: groups.ts unban <group-id> <ship> [<ship2> ...]\nExample: groups.ts unban ~host/group-slug ~nec`,
+  "add-role": `Usage: groups.ts add-role <group-id> <role-id> --title "..." [--description "..."]\nExample: groups.ts add-role ~host/group-slug editors --title "Editors"`,
+  "delete-role": `Usage: groups.ts delete-role <group-id> <role-id>\nExample: groups.ts delete-role ~host/group-slug editors`,
+  "update-role": `Usage: groups.ts update-role <group-id> <role-id> --title "..." [--description "..."]\nExample: groups.ts update-role ~host/group-slug editors --title "Writers"`,
+  "assign-role": `Usage: groups.ts assign-role <group-id> <role-id> <ship> [<ship2> ...]\nExample: groups.ts assign-role ~host/group-slug editors ~nec`,
+  "remove-role": `Usage: groups.ts remove-role <group-id> <role-id> <ship> [<ship2> ...]\nExample: groups.ts remove-role ~host/group-slug editors ~nec`,
+  "set-privacy": `Usage: groups.ts set-privacy <group-id> <public|private|secret>\nExample: groups.ts set-privacy ~host/group-slug private`,
+  "accept-join": `Usage: groups.ts accept-join <group-id> <ship> [<ship2> ...]\nExample: groups.ts accept-join ~host/group-slug ~nec`,
+  "reject-join": `Usage: groups.ts reject-join <group-id> <ship> [<ship2> ...]\nExample: groups.ts reject-join ~host/group-slug ~nec`,
+  promote: `Usage: groups.ts promote <group-id> <ship> [<ship2> ...]\nExample: groups.ts promote ~host/group-slug ~nec`,
+  demote: `Usage: groups.ts demote <group-id> <ship> [<ship2> ...]\nExample: groups.ts demote ~host/group-slug ~nec`,
+  "add-channel": `Usage: groups.ts add-channel <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]\nExample: groups.ts add-channel ~host/group-slug "Projects" --kind chat`,
+};
+
+function printGroupsHelp(command?: string) {
+  console.log(command ? GROUPS_COMMAND_HELP[command] ?? GROUPS_HELP : GROUPS_HELP);
 }
 
 // List all groups
@@ -570,6 +629,16 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
+  if (!command || command === "--help" || command === "-h") {
+    printGroupsHelp();
+    process.exit(0);
+  }
+
+  if (wantsHelp(args.slice(1))) {
+    printGroupsHelp(command);
+    process.exit(0);
+  }
+
   await ensureClient(['groups', 'channels']);
 
   switch (command) {
@@ -816,9 +885,12 @@ async function main() {
       const groupId = args[1];
       const title = args[2];
       if (!groupId || !title) {
-        console.error(
-          'Usage: groups.ts add-channel <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]'
-        );
+        console.error(GROUPS_COMMAND_HELP["add-channel"]);
+        process.exit(1);
+      }
+      if (looksLikePositionalChannelKind(args, 2)) {
+        console.error("Error: channel kind must be passed with --kind, not as a positional argument.");
+        console.error(GROUPS_COMMAND_HELP["add-channel"]);
         process.exit(1);
       }
       const kind = (getOption(args, "kind") as "chat" | "diary" | "heap") || "chat";
@@ -828,32 +900,7 @@ async function main() {
     }
 
     default:
-      console.log(`Usage: groups.ts <command>
-
-Commands:
-  list
-  create
-  invite
-  info
-  leave
-  join
-  delete
-  update
-  kick
-  ban
-  unban
-  add-role
-  delete-role
-  update-role
-  assign-role
-  remove-role
-  set-privacy
-  accept-join
-  reject-join
-  promote
-  demote
-  add-channel
-`);
+      printGroupsHelp();
       process.exit(1);
   }
   process.exit(0);


### PR DESCRIPTION
## Summary
- add reliable `--help` support for `groups` and `channels` subcommands
- add `tlon channels create` and `tlon channels rename` aliases for more discoverable channel ops
- guard against passing channel kind positionally (for example `groups add-channel <group> chat "Name"`)
- document the preferred channel-centric forms and add helper tests

## Why
The OpenClaw integration test failure showed the agent guessing CLI shapes like `channels create ...` and `channels rename ...`, then falling back to a malformed `groups add-channel` invocation that created a channel titled `chat`.

This patch makes the obvious command shapes work, improves help affordances, and blocks the common positional-kind footgun.

## Testing
- `bun test`
- `bun run build`
- `bun scripts/main.ts channels create --help`
- `bun scripts/main.ts channels rename --help`
- `bun scripts/main.ts groups add-channel --help`
