### PR TITLE
Fix bump-version workflow permissions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   bump:


### PR DESCRIPTION
## Summary
- grant `id-token: write` to the `Bump Version` workflow

## Why
The manually triggered `Bump Version` run failed at workflow startup before any jobs were created.

That workflow calls the reusable `publish.yml` workflow, whose publish job requests `id-token: write` for npm provenance/trusted publishing. The caller only granted `contents: write`, so GitHub rejected the run up front with a workflow-file startup failure.

## Testing
- inspected failed run `24250062433`
- verified the reusable `publish.yml` workflow requests `id-token: write`
- updated caller workflow permissions to allow the reusable workflow to request that token
