### PR TITLE
Update group join and invite flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ tlon contacts update-profile --nickname "My Name"
 
 # Create a group
 tlon groups create "My Group" --description "A cool group"
+
+# Join a public or invited group; private groups without an invite request one
+tlon groups join ~host/group-slug
+
+# Manage group invite flow explicitly
+tlon groups request-invite ~host/group-slug
+tlon groups accept-invite ~host/group-slug
+tlon groups reject-invite ~host/group-slug
 ```
 
 ## Features
@@ -129,7 +137,7 @@ tlon groups create "My Group" --description "A cool group"
 - **Activity**: Mentions, replies, unreads (with nicknames)
 - **Channels**: List DMs, group DMs, subscribed groups (nicknames shown), reader/writer permissions
 - **Contacts**: List, get, update profiles
-- **Groups**: Create, join, invite, roles, privacy (member nicknames shown)
+- **Groups**: Create, join, invite/request flows, roles, privacy (member nicknames shown)
 - **Hooks**: Manage channel hooks (add, edit, delete, order, config, cron)
 - **Messages**: History, search (author nicknames shown)
 - **DMs**: Send, react, accept/decline

--- a/SKILL.md
+++ b/SKILL.md
@@ -204,18 +204,24 @@ Full group management.
 tlon groups list                                         # List your groups
 tlon groups info ~host/slug                              # Get group details
 tlon groups create "Name" [--description "..."]          # Create a group
-tlon groups join ~host/slug                              # Join a group
+tlon groups join ~host/slug                              # Join public/invited group, or request invite if private
+tlon groups request-invite ~host/slug                    # Request invite to a private group
+tlon groups accept-invite ~host/slug                     # Accept an existing group invite
+tlon groups reject-invite ~host/slug                     # Reject an existing group invite
+tlon groups cancel-join ~host/slug                       # Cancel a pending join
+tlon groups rescind-request ~host/slug                   # Cancel an invite request
 tlon groups leave ~host/slug                             # Leave a group
 tlon groups delete ~host/slug                            # Delete (host only)
 tlon groups update ~host/slug --title "..." [--description "..."]
 
 # Members (shown with nicknames when available)
 tlon groups invite ~host/slug ~ship1 ~ship2              # Invite members
+tlon groups revoke-invite ~host/slug ~ship1              # Revoke pending member invite
 tlon groups kick ~host/slug ~ship1                       # Kick members
 tlon groups ban ~host/slug ~ship1                        # Ban members
 tlon groups unban ~host/slug ~ship1                      # Unban members
-tlon groups accept-join ~host/slug ~ship1                # Accept join request
-tlon groups reject-join ~host/slug ~ship1                # Reject join request
+tlon groups accept-join ~host/slug ~ship1                # Approve a member join request
+tlon groups reject-join ~host/slug ~ship1                # Deny a member join request
 tlon groups set-privacy ~host/slug public|private|secret # Set privacy
 
 # Roles
@@ -256,6 +262,12 @@ tlon groups add-channel --help
 ```
 
 Group format: `~host-ship/group-slug`
+
+Join behavior:
+- `join` first checks whether you are already a member, then checks foreign/unjoined group state for a valid invite.
+- Invited groups and public groups use the backend join action.
+- Private groups without an invite use the invite-request action.
+- Secret groups require an invite.
 
 ### Hooks
 

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -9,6 +9,12 @@
  *   npx ts-node scripts/groups.ts info <group-id>
  *   npx ts-node scripts/groups.ts leave <group-id>
  *   npx ts-node scripts/groups.ts join <group-id>
+ *   npx ts-node scripts/groups.ts request-invite <group-id>
+ *   npx ts-node scripts/groups.ts accept-invite <group-id>
+ *   npx ts-node scripts/groups.ts reject-invite <group-id>
+ *   npx ts-node scripts/groups.ts cancel-join <group-id>
+ *   npx ts-node scripts/groups.ts rescind-request <group-id>
+ *   npx ts-node scripts/groups.ts revoke-invite <group-id> <ship> [<ship2> ...]
  *   npx ts-node scripts/groups.ts delete <group-id>
  *   npx ts-node scripts/groups.ts update <group-id> --title "..." [--description "..."] [--image "..."]
  *   npx ts-node scripts/groups.ts kick <group-id> <ship> [<ship2> ...]
@@ -32,6 +38,7 @@ import {
   addGroupRole,
   addMembersToRole,
   banUsersFromGroup,
+  cancelGroupJoin as apiCancelGroupJoin,
   createChannel,
   createGroup,
   deleteGroup,
@@ -39,14 +46,21 @@ import {
   getContacts,
   getCurrentUserId,
   getGroup,
+  getGroupPreview,
   getGroups,
   inviteGroupMembers,
+  joinGroup as apiJoinGroup,
   kickUsersFromGroup,
   leaveGroup,
   poke,
+  rejectGroupInvitation,
   rejectGroupJoin,
   removeMembersFromRole,
   requestGroupInvitation,
+  rescindGroupInvitationRequest,
+  revokeGroupMemberInvites,
+  scry,
+  toClientGroupsFromForeigns,
   unbanUsersFromGroup,
   updateGroupMeta,
   updateGroupPrivacy,
@@ -77,6 +91,12 @@ Commands:
   info <group-id>
   leave <group-id>
   join <group-id>
+  request-invite <group-id>
+  accept-invite <group-id>
+  reject-invite <group-id>
+  cancel-join <group-id>
+  rescind-request <group-id>
+  revoke-invite <group-id> <ship> [<ship2> ...]
   delete <group-id>
   update <group-id> --title "..." [--description "..."] [--image "..."] [--cover "..."]
   kick <group-id> <ship> [<ship2> ...]
@@ -104,7 +124,13 @@ const GROUPS_COMMAND_HELP: Record<string, string> = {
   invite: `Usage: groups.ts invite <group-id> <ship> [<ship2> ...]\nExample: groups.ts invite ~host/group-slug ~nec ~bud`,
   info: `Usage: groups.ts info <group-id>\nExample: groups.ts info ~host/group-slug`,
   leave: `Usage: groups.ts leave <group-id>\nExample: groups.ts leave ~host/group-slug`,
-  join: `Usage: groups.ts join <group-id>\nExample: groups.ts join ~host/group-slug`,
+  join: `Usage: groups.ts join <group-id>\nJoins public or invited groups. For private groups without an invite, requests an invite.\nExample: groups.ts join ~host/group-slug`,
+  "request-invite": `Usage: groups.ts request-invite <group-id>\nExample: groups.ts request-invite ~host/group-slug`,
+  "accept-invite": `Usage: groups.ts accept-invite <group-id>\nExample: groups.ts accept-invite ~host/group-slug`,
+  "reject-invite": `Usage: groups.ts reject-invite <group-id>\nExample: groups.ts reject-invite ~host/group-slug`,
+  "cancel-join": `Usage: groups.ts cancel-join <group-id>\nExample: groups.ts cancel-join ~host/group-slug`,
+  "rescind-request": `Usage: groups.ts rescind-request <group-id>\nExample: groups.ts rescind-request ~host/group-slug`,
+  "revoke-invite": `Usage: groups.ts revoke-invite <group-id> <ship> [<ship2> ...]\nExample: groups.ts revoke-invite ~host/group-slug ~nec`,
   delete: `Usage: groups.ts delete <group-id>\nExample: groups.ts delete ~host/group-slug`,
   update: `Usage: groups.ts update <group-id> --title "..." [--description "..."] [--image "..."] [--cover "..."]\nExample: groups.ts update ~host/group-slug --title "New Title"`,
   kick: `Usage: groups.ts kick <group-id> <ship> [<ship2> ...]\nExample: groups.ts kick ~host/group-slug ~nec`,
@@ -190,7 +216,7 @@ async function getGroupInfo(groupId: string) {
 
   console.log("\n--- Members ---");
   for (const member of group.members || []) {
-    const roles = (member.roles || []).map((r) => r.roleId);
+    const roles = (member.roles || []).map((r: { roleId: string }) => r.roleId);
     const roleList = roles.length > 0 ? ` [${roles.join(", ")}]` : "";
     const displayName = formatShipWithNickname(member.contactId, nicknameMap);
     console.log(`  ${displayName}${roleList}`);
@@ -298,11 +324,124 @@ async function leaveGroupById(groupId: string) {
 
 // Join a group
 async function joinGroupById(groupId: string) {
+  const joinedGroup = await getJoinedGroupState(groupId);
+  if (joinedGroup?.currentUserIsMember) {
+    console.log(`Already a member of ${groupId}.`);
+    return;
+  }
+
+  const foreignGroup = await getForeignGroupState(groupId);
+  if (foreignGroup?.haveInvite) {
+    await acceptInvite(groupId);
+    return;
+  }
+
+  if (foreignGroup?.haveRequestedInvite) {
+    console.log(`Invite already requested for ${groupId}.`);
+    return;
+  }
+
+  const group = foreignGroup ?? (await getGroupPreviewState(groupId));
+
+  if (group?.privacy === "public") {
+    await joinNow(groupId);
+    return;
+  }
+
+  if (group?.privacy === "private") {
+    await requestInvite(groupId);
+    return;
+  }
+
+  if (group?.privacy === "secret") {
+    throw new Error(`Cannot join secret group ${groupId} without an invite.`);
+  }
+
+  console.log(`Group privacy unknown for ${groupId}; attempting join...`);
+  await joinNow(groupId);
+}
+
+async function getJoinedGroupState(groupId: string): Promise<Group | null> {
+  try {
+    return await getGroup(groupId);
+  } catch {
+    return null;
+  }
+}
+
+async function getForeignGroupState(groupId: string): Promise<Group | null> {
+  try {
+    const foreigns = await scry<Record<string, unknown>>({
+      app: "groups",
+      path: "/v1/foreigns",
+    });
+    const groups = toClientGroupsFromForeigns(foreigns as any);
+    return groups.find((group: Group) => group.id === groupId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function getGroupPreviewState(groupId: string): Promise<Group | null> {
+  try {
+    return await getGroupPreview(groupId);
+  } catch {
+    try {
+      const groups = await getGroups();
+      return groups.find((group) => group.id === groupId) ?? null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function joinNow(groupId: string) {
   console.log(`Joining group ${groupId}...`);
+  await apiJoinGroup(groupId);
+  console.log(`✅ Join requested. Sync may take a moment to show membership.`);
+}
 
+async function requestInvite(groupId: string) {
+  console.log(`Requesting invite to ${groupId}...`);
   await requestGroupInvitation(groupId);
+  console.log(`✅ Invite requested.`);
+}
 
-  console.log(`✅ Join request sent! (May need approval if group is private)`);
+async function acceptInvite(groupId: string) {
+  console.log(`Accepting invite to ${groupId}...`);
+  await apiJoinGroup(groupId);
+  console.log(`✅ Invite accepted, joining group. Sync may take a moment to show membership.`);
+}
+
+async function rejectInvite(groupId: string) {
+  console.log(`Rejecting invite to ${groupId}...`);
+  await rejectGroupInvitation(groupId);
+  console.log(`✅ Invite rejected.`);
+}
+
+async function cancelJoin(groupId: string) {
+  console.log(`Canceling join for ${groupId}...`);
+  await apiCancelGroupJoin(groupId);
+  console.log(`✅ Join canceled.`);
+}
+
+async function rescindInviteRequest(groupId: string) {
+  console.log(`Rescinding invite request for ${groupId}...`);
+  await rescindGroupInvitationRequest(groupId);
+  console.log(`✅ Invite request rescinded.`);
+}
+
+async function revokeInvites(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(`Revoking invites for ${normalizedShips.join(", ")} from ${groupId}...`);
+
+  await revokeGroupMemberInvites({
+    groupId,
+    contactIds: normalizedShips,
+  });
+
+  console.log(`✅ Invites revoked.`);
 }
 
 // Delete a group (must be host)
@@ -691,10 +830,71 @@ async function main() {
     case "join": {
       const groupId = args[1];
       if (!groupId) {
-        console.error("Usage: groups.ts join <group-id>");
+        console.error(GROUPS_COMMAND_HELP.join);
         process.exit(1);
       }
       await joinGroupById(groupId);
+      break;
+    }
+
+    case "request-invite": {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP["request-invite"]);
+        process.exit(1);
+      }
+      await requestInvite(groupId);
+      break;
+    }
+
+    case "accept-invite": {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP["accept-invite"]);
+        process.exit(1);
+      }
+      await acceptInvite(groupId);
+      break;
+    }
+
+    case "reject-invite": {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP["reject-invite"]);
+        process.exit(1);
+      }
+      await rejectInvite(groupId);
+      break;
+    }
+
+    case "cancel-join": {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP["cancel-join"]);
+        process.exit(1);
+      }
+      await cancelJoin(groupId);
+      break;
+    }
+
+    case "rescind-request": {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP["rescind-request"]);
+        process.exit(1);
+      }
+      await rescindInviteRequest(groupId);
+      break;
+    }
+
+    case "revoke-invite": {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        console.error(GROUPS_COMMAND_HELP["revoke-invite"]);
+        process.exit(1);
+      }
+      await revokeInvites(groupId, ships);
       break;
     }
 

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -33,7 +33,7 @@ Commands:
   contacts     Contact/profile management (list, get, self, sync, add, remove, update-profile)
   dms          Direct message operations (send, reply, react, unreact, delete, accept, decline)
   expose       Manage public content exposure (list, show, hide, check, url)
-  groups       Group management (list, create, info, invite, join, leave, delete, ...)
+  groups       Group management (list, create, info, join, request/accept invites, leave, delete, ...)
   hooks        Channel hooks management (list, add, edit, delete, order, config, cron, rest)
   messages     Message history and search (dm, channel, history, search, context, post)
   notebook     Post to diary/notebook channels
@@ -67,6 +67,7 @@ Examples:
   tlon contacts list
   tlon messages dm ~sampel-palnet --limit 10
   tlon groups create "My Group" --description "A cool group"
+  tlon groups join ~host/group-slug
   tlon posts react chat/~host/channel 170.141.184... 👍
   tlon --config ~/ships/zod.json contacts self
   tlon --url https://zod.tlon.network --cookie "urbauth-~zod=0v..." contacts self


### PR DESCRIPTION
## Summary
- make `groups join` distinguish joined, invited, public, private, and secret group states
- add explicit group invite commands for request/accept/reject/cancel/rescind/revoke flows
- update README, skill docs, and top-level CLI help

## Test plan
- npm test -- --run
- npx tsc --noEmit --pretty false --target ES2022 --module CommonJS --moduleResolution Node --esModuleInterop --strict --skipLibCheck scripts/groups.ts

Note: full project typecheck still reports pre-existing unrelated errors in other scripts.