### PR TITLE
add combined create invite admin command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 # Ignore binaries, keep package.json
 npm/*/tlon
 bin/tlon
+.claude/settings.local.json
+ships/*

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ tlon contacts update-profile --nickname "My Name"
 # Create a group
 tlon groups create "My Group" --description "A cool group"
 
+# Create a group for a bot owner
+tlon groups create-owned "My Group" --owner ~owner-ship --description "A cool group"
+
 # Join a public or invited group; private groups without an invite request one
 tlon groups join ~host/group-slug
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -228,7 +228,7 @@ Full group management.
 tlon groups list                                         # List your groups
 tlon groups info ~host/slug                              # Get group details
 tlon groups create "Name" [--description "..."]          # Create a group
-tlon groups create-owned "Name" --owner ~ship            # Create group, invite owner, make owner admin
+tlon groups create-owned "Name" --owner ~ship [--description "..."] # Create group, invite owner, make owner admin
 tlon groups join ~host/slug                              # Join public/invited group, or request invite if private
 tlon groups request-invite ~host/slug                    # Request invite to a private group
 tlon groups accept-invite ~host/slug                     # Accept an existing group invite

--- a/SKILL.md
+++ b/SKILL.md
@@ -228,6 +228,7 @@ Full group management.
 tlon groups list                                         # List your groups
 tlon groups info ~host/slug                              # Get group details
 tlon groups create "Name" [--description "..."]          # Create a group
+tlon groups create-owned "Name" --owner ~ship            # Create group, invite owner, make owner admin
 tlon groups join ~host/slug                              # Join public/invited group, or request invite if private
 tlon groups request-invite ~host/slug                    # Request invite to a private group
 tlon groups accept-invite ~host/slug                     # Accept an existing group invite

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tloncorp/tlon-skill",
-  "version": "0.3.3",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tloncorp/tlon-skill",
-      "version": "0.3.3",
+      "version": "0.3.6",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -19,10 +19,10 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@tloncorp/tlon-skill-darwin-arm64": "0.3.2",
-        "@tloncorp/tlon-skill-darwin-x64": "0.3.2",
-        "@tloncorp/tlon-skill-linux-arm64": "0.3.2",
-        "@tloncorp/tlon-skill-linux-x64": "0.3.2"
+        "@tloncorp/tlon-skill-darwin-arm64": "0.3.6",
+        "@tloncorp/tlon-skill-darwin-x64": "0.3.6",
+        "@tloncorp/tlon-skill-linux-arm64": "0.3.6",
+        "@tloncorp/tlon-skill-linux-x64": "0.3.6"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1873,6 +1873,70 @@
         "lodash": "^4.17.21",
         "sorted-btree": "^1.8.1",
         "validator": "^13.7.0"
+      }
+    },
+    "node_modules/@tloncorp/tlon-skill-darwin-arm64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-arm64/-/tlon-skill-darwin-arm64-0.3.6.tgz",
+      "integrity": "sha512-vR6OeFsIGg9K1QVG2ZZaMC+8QuTyoEp0mGwEJPCooMXF2FxAHTzAE99CNgTmNZbCkCDXIsCL9jMJTcfUNr6xyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "tlon": "tlon"
+      }
+    },
+    "node_modules/@tloncorp/tlon-skill-darwin-x64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-x64/-/tlon-skill-darwin-x64-0.3.6.tgz",
+      "integrity": "sha512-7A1MLaJ09THCLVOWu/mdzWBDi64md6CLnAlKByduBuza3Osz2VwhJvZb6aVZXQamiKt9vB5yjqPIUvS2AZRhsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "tlon": "tlon"
+      }
+    },
+    "node_modules/@tloncorp/tlon-skill-linux-arm64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@tloncorp/tlon-skill-linux-arm64/-/tlon-skill-linux-arm64-0.3.6.tgz",
+      "integrity": "sha512-VaMDV78GakJtUNvDF5ItZ1/ahw86hq6UtfCCeTRZU/Rkapluj2XSFI/t4oVxEMNKi9/urRVO3b6V8IklUnRQBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "tlon": "tlon"
+      }
+    },
+    "node_modules/@tloncorp/tlon-skill-linux-x64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@tloncorp/tlon-skill-linux-x64/-/tlon-skill-linux-x64-0.3.6.tgz",
+      "integrity": "sha512-Yp/f6GWuUkNv6k72inX7fY5rf0xxpZpdvmS/U0JWLI5uAk04TiG75ayZIAqJw+Pwp8DRmDGoasH6WfOVjOPHog==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "tlon": "tlon"
       }
     },
     "node_modules/@types/node": {

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -208,6 +208,10 @@ type CreatedGroup = {
   channelId: string;
 };
 
+type CreateGroupWithChannelOptions = {
+  memberIds?: string[];
+};
+
 type OwnerAdminVerification =
   | { status: "verified" }
   | { status: "missing"; reason: string };
@@ -220,8 +224,6 @@ type RawGroupForAdminVerification = {
     invited?: Record<string, unknown>;
   };
 };
-
-type PendingInviteRoleAction = "add" | "edit";
 
 const VERIFY_ATTEMPTS = 5;
 const VERIFY_DELAY_MS = 500;
@@ -247,18 +249,6 @@ function getShipRecordValue<T>(record: Record<string, T> | undefined, ship: stri
   return Object.entries(record).find(([key]) => normalizeShip(key) === ship)?.[1];
 }
 
-function mergeRoleIds(roleIds: string[] | undefined, roleId: string): string[] {
-  return Array.from(new Set([...(roleIds ?? []), roleId]));
-}
-
-function hasOwnerAdmission(rawGroup: RawGroupForAdminVerification, ownerShip: string): boolean {
-  return (
-    getShipRecordValue(rawGroup.seats, ownerShip) !== undefined ||
-    getShipRecordValue(rawGroup.admissions?.pending, ownerShip) !== undefined ||
-    getShipRecordValue(rawGroup.admissions?.invited, ownerShip) !== undefined
-  );
-}
-
 async function getRawGroupForAdminVerification(
   groupId: string
 ): Promise<RawGroupForAdminVerification> {
@@ -268,7 +258,11 @@ async function getRawGroupForAdminVerification(
   });
 }
 
-async function getRawGroupWithOwnerAdmission(
+function hasOwnerSeat(rawGroup: RawGroupForAdminVerification, ownerShip: string): boolean {
+  return getShipRecordValue(rawGroup.seats, ownerShip) !== undefined;
+}
+
+async function getRawGroupWithOwnerSeat(
   groupId: string,
   ownerShip: string
 ): Promise<RawGroupForAdminVerification> {
@@ -277,7 +271,7 @@ async function getRawGroupWithOwnerAdmission(
   for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
     try {
       const rawGroup = await getRawGroupForAdminVerification(groupId);
-      if (hasOwnerAdmission(rawGroup, ownerShip)) {
+      if (hasOwnerSeat(rawGroup, ownerShip)) {
         return rawGroup;
       }
     } catch (err) {
@@ -289,8 +283,9 @@ async function getRawGroupWithOwnerAdmission(
     }
   }
 
+  const suffix = lastError ? `: ${lastError}` : "";
   throw new Error(
-    `Owner ${ownerShip} was not found in members or pending invites for ${groupId}: ${lastError}`
+    `Owner ${ownerShip} was not created as an invited member seat in ${groupId}${suffix}`
   );
 }
 
@@ -322,7 +317,10 @@ async function getRawOwnerAdminVerification(
   const pendingRoles = getShipRecordValue(rawGroup.admissions?.pending, ownerShip);
   if (pendingRoles) {
     if (pendingRoles.includes(ADMIN_ROLE_ID)) {
-      return { status: "verified" };
+      return {
+        status: "missing",
+        reason: `Owner ${ownerShip} has a pending invite for ${groupId} with the "${ADMIN_ROLE_ID}" role, but is not a group member seat yet.`,
+      };
     }
 
     return {
@@ -345,56 +343,22 @@ async function getRawOwnerAdminVerification(
   };
 }
 
-async function setPendingInviteRoles(
-  groupId: string,
-  ships: string[],
-  roleIds: string[],
-  action: PendingInviteRoleAction
-) {
-  const pendingAction =
-    action === "add" ? { add: roleIds } : { edit: roleIds };
-
-  await poke({
-    app: "groups",
-    mark: "group-action-4",
-    json: {
-      group: {
-        flag: groupId,
-        "a-group": {
-          entry: {
-            pending: {
-              ships,
-              "a-pending": pendingAction,
-            },
-          },
-        },
-      },
-    },
-  });
-}
-
 async function assignOwnerAdminRole(groupId: string, ownerShip: string) {
-  const rawGroup = await getRawGroupWithOwnerAdmission(groupId, ownerShip);
+  const rawGroup = await getRawGroupWithOwnerSeat(groupId, ownerShip);
   const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip);
 
-  if (ownerSeat) {
-    console.log(`Assigning owner ${ownerShip} to "${ADMIN_ROLE_ID}" role...`);
-    await addMembersToRole({
-      groupId,
-      roleId: ADMIN_ROLE_ID,
-      ships: [ownerShip],
-    });
-    console.log(`✅ Owner assigned to "${ADMIN_ROLE_ID}" role.`);
+  if (ownerSeat?.roles?.includes(ADMIN_ROLE_ID)) {
+    console.log(`✅ Owner already has "${ADMIN_ROLE_ID}" role.`);
     return;
   }
 
-  const pendingRoles = getShipRecordValue(rawGroup.admissions?.pending, ownerShip);
-  const roleIds = mergeRoleIds(pendingRoles, ADMIN_ROLE_ID);
-  const action = pendingRoles === undefined ? "add" : "edit";
-
-  console.log(`Assigning owner ${ownerShip} to pending "${ADMIN_ROLE_ID}" role...`);
-  await setPendingInviteRoles(groupId, [ownerShip], roleIds, action);
-  console.log(`✅ Owner pending invite assigned to "${ADMIN_ROLE_ID}" role.`);
+  console.log(`Assigning owner ${ownerShip} to "${ADMIN_ROLE_ID}" role...`);
+  await addMembersToRole({
+    groupId,
+    roleId: ADMIN_ROLE_ID,
+    ships: [ownerShip],
+  });
+  console.log(`✅ Owner assigned to "${ADMIN_ROLE_ID}" role.`);
 }
 
 async function getGroupWithRetry(groupId: string): Promise<Group> {
@@ -553,7 +517,11 @@ async function getGroupInfo(groupId: string) {
 }
 
 // Create a new group
-async function createGroupWithChannel(title: string, description: string = ""): Promise<CreatedGroup> {
+async function createGroupWithChannel(
+  title: string,
+  description: string = "",
+  options: CreateGroupWithChannelOptions = {}
+): Promise<CreatedGroup> {
   const ship = await getCurrentShip();
   const slug = generateGroupSlug();
   const groupId = `${ship}/${slug}`;
@@ -582,6 +550,7 @@ async function createGroupWithChannel(title: string, description: string = ""): 
 
   await createGroup({
     group,
+    memberIds: options.memberIds,
   });
 
   if (description) {
@@ -608,18 +577,12 @@ async function createGroupWithChannel(title: string, description: string = ""): 
 
 async function createOwnedGroup(title: string, owner: string, description: string = "") {
   const ownerShip = normalizeShip(owner);
-  const { groupId, channelId } = await createGroupWithChannel(title, description);
+  const { groupId, channelId } = await createGroupWithChannel(title, description, {
+    memberIds: [ownerShip],
+  });
   const createdGroup = await verifyGroupCreated(groupId);
 
   await ensureAdminRole(groupId, createdGroup);
-
-  console.log(`Inviting owner ${ownerShip} to ${groupId}...`);
-  await inviteGroupMembers({
-    groupId,
-    contactIds: [ownerShip],
-  });
-  console.log(`✅ Owner invited.`);
-
   await assignOwnerAdminRole(groupId, ownerShip);
   await verifyOwnerAdmin(groupId, ownerShip);
 

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -1066,7 +1066,7 @@ async function main() {
     case "create-owned": {
       const title = args[1];
       const owner = getOption(args, "owner");
-      if (!title || !owner || owner.startsWith("--")) {
+      if (!title || title.startsWith("--") || !owner || owner.startsWith("--")) {
         console.error(GROUPS_COMMAND_HELP["create-owned"]);
         process.exit(1);
       }

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -420,9 +420,9 @@ async function ensureAdminRole(groupId: string, group?: Group) {
       roleId: ADMIN_ROLE_ID,
       meta: { title: "Admin", description: "Group administrator" },
     });
-  }
 
-  await setAdminRole(groupId, ADMIN_ROLE_ID);
+    await setAdminRole(groupId, ADMIN_ROLE_ID);
+  }
 }
 
 async function verifyOwnerAdmin(groupId: string, ownerShip: string): Promise<void> {

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -206,6 +206,7 @@ function formatShipWithNickname(ship: string, nicknameMap: Map<string, string>):
 type CreatedGroup = {
   groupId: string;
   channelId: string;
+  group: Group;
 };
 
 type CreateGroupWithChannelOptions = {
@@ -553,6 +554,8 @@ async function createGroupWithChannel(
     memberIds: options.memberIds,
   });
 
+  const createdGroup = await verifyGroupCreated(groupId);
+
   if (description) {
     console.log(`Setting group description...`);
     await updateGroupMeta({
@@ -572,17 +575,16 @@ async function createGroupWithChannel(
   console.log(`   Description: ${description || "(none)"}`);
   console.log(`   Channel: ${channelId}`);
 
-  return { groupId, channelId };
+  return { groupId, channelId, group: createdGroup };
 }
 
 async function createOwnedGroup(title: string, owner: string, description: string = "") {
   const ownerShip = normalizeShip(owner);
-  const { groupId, channelId } = await createGroupWithChannel(title, description, {
+  const { groupId, channelId, group } = await createGroupWithChannel(title, description, {
     memberIds: [ownerShip],
   });
-  const createdGroup = await verifyGroupCreated(groupId);
 
-  await ensureAdminRole(groupId, createdGroup);
+  await ensureAdminRole(groupId, group);
   await assignOwnerAdminRole(groupId, ownerShip);
   await verifyOwnerAdmin(groupId, ownerShip);
 

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -5,6 +5,7 @@
  * Usage:
  *   npx ts-node scripts/groups.ts list
  *   npx ts-node scripts/groups.ts create "Group Name" [--description "..."]
+ *   npx ts-node scripts/groups.ts create-owned "Group Name" --owner <ship> [--description "..."]
  *   npx ts-node scripts/groups.ts invite <group-id> <ship> [<ship2> ...]
  *   npx ts-node scripts/groups.ts info <group-id>
  *   npx ts-node scripts/groups.ts leave <group-id>
@@ -70,6 +71,8 @@ import type { Group } from "@tloncorp/api";
 import { ensureClient, getCurrentShip, normalizeShip } from "./api-client";
 import { getOption, looksLikePositionalChannelKind, wantsHelp } from "./cli-utils";
 
+const ADMIN_ROLE_ID = "admin";
+
 // Generate a random short ID for the group
 function generateGroupSlug(): string {
   // Must be valid @tas: lowercase letters, numbers, hyphens, must start with letter
@@ -87,6 +90,7 @@ const GROUPS_HELP = `Usage: groups.ts <command>
 Commands:
   list
   create "Group Name" [--description "..."]
+  create-owned "Group Name" --owner <ship> [--description "..."]
   invite <group-id> <ship> [<ship2> ...]
   info <group-id>
   leave <group-id>
@@ -121,6 +125,7 @@ Examples:
 const GROUPS_COMMAND_HELP: Record<string, string> = {
   list: `Usage: groups.ts list`,
   create: `Usage: groups.ts create "Group Name" [--description "..."]\nExample: groups.ts create "Projects" --description "Shared work"`,
+  "create-owned": `Usage: groups.ts create-owned "Group Name" --owner <ship> [--description "..."]\nExample: groups.ts create-owned "Projects" --owner ~nec --description "Shared work"`,
   invite: `Usage: groups.ts invite <group-id> <ship> [<ship2> ...]\nExample: groups.ts invite ~host/group-slug ~nec ~bud`,
   info: `Usage: groups.ts info <group-id>\nExample: groups.ts info ~host/group-slug`,
   leave: `Usage: groups.ts leave <group-id>\nExample: groups.ts leave ~host/group-slug`,
@@ -198,6 +203,294 @@ function formatShipWithNickname(ship: string, nicknameMap: Map<string, string>):
   return nickname ? `${ship} (${nickname})` : ship;
 }
 
+type CreatedGroup = {
+  groupId: string;
+  channelId: string;
+};
+
+type OwnerAdminVerification =
+  | { status: "verified" }
+  | { status: "missing"; reason: string };
+
+type RawGroupForAdminVerification = {
+  admins?: string[];
+  seats?: Record<string, { roles?: string[] }>;
+  admissions?: {
+    pending?: Record<string, string[]>;
+    invited?: Record<string, unknown>;
+  };
+};
+
+type PendingInviteRoleAction = "add" | "edit";
+
+const VERIFY_ATTEMPTS = 5;
+const VERIFY_DELAY_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function groupHasRole(group: Group, roleId: string): boolean {
+  return (group.roles || []).some((role) => role.id === roleId);
+}
+
+function getShipRecordValue<T>(record: Record<string, T> | undefined, ship: string): T | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  const direct = record[ship];
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  return Object.entries(record).find(([key]) => normalizeShip(key) === ship)?.[1];
+}
+
+function mergeRoleIds(roleIds: string[] | undefined, roleId: string): string[] {
+  return Array.from(new Set([...(roleIds ?? []), roleId]));
+}
+
+function hasOwnerAdmission(rawGroup: RawGroupForAdminVerification, ownerShip: string): boolean {
+  return (
+    getShipRecordValue(rawGroup.seats, ownerShip) !== undefined ||
+    getShipRecordValue(rawGroup.admissions?.pending, ownerShip) !== undefined ||
+    getShipRecordValue(rawGroup.admissions?.invited, ownerShip) !== undefined
+  );
+}
+
+async function getRawGroupForAdminVerification(
+  groupId: string
+): Promise<RawGroupForAdminVerification> {
+  return scry<RawGroupForAdminVerification>({
+    app: "groups",
+    path: `/v2/ui/groups/${groupId}`,
+  });
+}
+
+async function getRawGroupWithOwnerAdmission(
+  groupId: string,
+  ownerShip: string
+): Promise<RawGroupForAdminVerification> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      const rawGroup = await getRawGroupForAdminVerification(groupId);
+      if (hasOwnerAdmission(rawGroup, ownerShip)) {
+        return rawGroup;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+
+    if (attempt < VERIFY_ATTEMPTS) {
+      await sleep(VERIFY_DELAY_MS);
+    }
+  }
+
+  throw new Error(
+    `Owner ${ownerShip} was not found in members or pending invites for ${groupId}: ${lastError}`
+  );
+}
+
+async function getRawOwnerAdminVerification(
+  groupId: string,
+  ownerShip: string
+): Promise<OwnerAdminVerification> {
+  const rawGroup = await getRawGroupForAdminVerification(groupId);
+
+  if (!rawGroup.admins?.includes(ADMIN_ROLE_ID)) {
+    return {
+      status: "missing",
+      reason: `Group ${groupId} has an "${ADMIN_ROLE_ID}" role, but it is not marked as an admin role.`,
+    };
+  }
+
+  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip);
+  if (ownerSeat) {
+    if (ownerSeat.roles?.includes(ADMIN_ROLE_ID)) {
+      return { status: "verified" };
+    }
+
+    return {
+      status: "missing",
+      reason: `Owner ${ownerShip} is a member of ${groupId}, but does not have the "${ADMIN_ROLE_ID}" role.`,
+    };
+  }
+
+  const pendingRoles = getShipRecordValue(rawGroup.admissions?.pending, ownerShip);
+  if (pendingRoles) {
+    if (pendingRoles.includes(ADMIN_ROLE_ID)) {
+      return { status: "verified" };
+    }
+
+    return {
+      status: "missing",
+      reason: `Owner ${ownerShip} has a pending invite for ${groupId}, but not with the "${ADMIN_ROLE_ID}" role.`,
+    };
+  }
+
+  const ownerInvite = getShipRecordValue(rawGroup.admissions?.invited, ownerShip);
+  if (ownerInvite) {
+    return {
+      status: "missing",
+      reason: `Owner ${ownerShip} is invited to ${groupId}, but no pending "${ADMIN_ROLE_ID}" role assignment was found.`,
+    };
+  }
+
+  return {
+    status: "missing",
+    reason: `Owner ${ownerShip} was not found in members or pending invites for ${groupId}.`,
+  };
+}
+
+async function setPendingInviteRoles(
+  groupId: string,
+  ships: string[],
+  roleIds: string[],
+  action: PendingInviteRoleAction
+) {
+  const pendingAction =
+    action === "add" ? { add: roleIds } : { edit: roleIds };
+
+  await poke({
+    app: "groups",
+    mark: "group-action-4",
+    json: {
+      group: {
+        flag: groupId,
+        "a-group": {
+          entry: {
+            pending: {
+              ships,
+              "a-pending": pendingAction,
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+async function assignOwnerAdminRole(groupId: string, ownerShip: string) {
+  const rawGroup = await getRawGroupWithOwnerAdmission(groupId, ownerShip);
+  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip);
+
+  if (ownerSeat) {
+    console.log(`Assigning owner ${ownerShip} to "${ADMIN_ROLE_ID}" role...`);
+    await addMembersToRole({
+      groupId,
+      roleId: ADMIN_ROLE_ID,
+      ships: [ownerShip],
+    });
+    console.log(`✅ Owner assigned to "${ADMIN_ROLE_ID}" role.`);
+    return;
+  }
+
+  const pendingRoles = getShipRecordValue(rawGroup.admissions?.pending, ownerShip);
+  const roleIds = mergeRoleIds(pendingRoles, ADMIN_ROLE_ID);
+  const action = pendingRoles === undefined ? "add" : "edit";
+
+  console.log(`Assigning owner ${ownerShip} to pending "${ADMIN_ROLE_ID}" role...`);
+  await setPendingInviteRoles(groupId, [ownerShip], roleIds, action);
+  console.log(`✅ Owner pending invite assigned to "${ADMIN_ROLE_ID}" role.`);
+}
+
+async function getGroupWithRetry(groupId: string): Promise<Group> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      return await getGroup(groupId);
+    } catch (err) {
+      lastError = err;
+      if (attempt < VERIFY_ATTEMPTS) {
+        await sleep(VERIFY_DELAY_MS);
+      }
+    }
+  }
+
+  throw new Error(`Could not fetch group ${groupId} for verification: ${lastError}`);
+}
+
+async function verifyGroupCreated(groupId: string): Promise<Group> {
+  console.log(`Verifying group ${groupId}...`);
+  const group = await getGroupWithRetry(groupId);
+
+  if (group.id && group.id !== groupId) {
+    throw new Error(`Created group verification returned ${group.id}, expected ${groupId}.`);
+  }
+
+  console.log(`✅ Group verified.`);
+  return group;
+}
+
+async function setAdminRole(groupId: string, roleId: string) {
+  await poke({
+    app: "groups",
+    mark: "group-action-4",
+    json: {
+      group: {
+        flag: groupId,
+        "a-group": {
+          role: {
+            roles: [roleId],
+            "a-role": {
+              "set-admin": null,
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+async function ensureAdminRole(groupId: string, group?: Group) {
+  const currentGroup = group ?? (await getGroup(groupId));
+
+  if (!groupHasRole(currentGroup, ADMIN_ROLE_ID)) {
+    console.log(`Creating "${ADMIN_ROLE_ID}" role in ${groupId}...`);
+    await addGroupRole({
+      groupId,
+      roleId: ADMIN_ROLE_ID,
+      meta: { title: "Admin", description: "Group administrator" },
+    });
+  }
+
+  await setAdminRole(groupId, ADMIN_ROLE_ID);
+}
+
+async function verifyOwnerAdmin(groupId: string, ownerShip: string): Promise<void> {
+  console.log(`Verifying ${ownerShip} admin assignment in ${groupId}...`);
+
+  let lastVerification: OwnerAdminVerification | null = null;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      const rawVerification = await getRawOwnerAdminVerification(groupId, ownerShip);
+      if (rawVerification.status === "verified") {
+        console.log(`✅ Owner admin assignment verified.`);
+        return;
+      }
+      lastVerification = rawVerification;
+    } catch (err) {
+      lastError = err;
+    }
+
+    if (attempt < VERIFY_ATTEMPTS) {
+      await sleep(VERIFY_DELAY_MS);
+    }
+  }
+
+  if (lastVerification) {
+    throw new Error(lastVerification.reason);
+  }
+
+  throw new Error(`Could not verify owner admin assignment for ${ownerShip}: ${lastError}`);
+}
+
 // Get info about a specific group
 async function getGroupInfo(groupId: string) {
   const [group, nicknameMap] = await Promise.all([
@@ -260,7 +553,7 @@ async function getGroupInfo(groupId: string) {
 }
 
 // Create a new group
-async function createGroupWithChannel(title: string, description: string = "") {
+async function createGroupWithChannel(title: string, description: string = ""): Promise<CreatedGroup> {
   const ship = await getCurrentShip();
   const slug = generateGroupSlug();
   const groupId = `${ship}/${slug}`;
@@ -291,12 +584,53 @@ async function createGroupWithChannel(title: string, description: string = "") {
     group,
   });
 
+  if (description) {
+    console.log(`Setting group description...`);
+    await updateGroupMeta({
+      groupId,
+      meta: {
+        title,
+        description,
+        image: "",
+        cover: "",
+      },
+    });
+  }
+
   console.log(`✅ Group created successfully!`);
   console.log(`   ID: ${groupId}`);
   console.log(`   Title: ${title}`);
+  console.log(`   Description: ${description || "(none)"}`);
   console.log(`   Channel: ${channelId}`);
 
-  return groupId;
+  return { groupId, channelId };
+}
+
+async function createOwnedGroup(title: string, owner: string, description: string = "") {
+  const ownerShip = normalizeShip(owner);
+  const { groupId, channelId } = await createGroupWithChannel(title, description);
+  const createdGroup = await verifyGroupCreated(groupId);
+
+  await ensureAdminRole(groupId, createdGroup);
+
+  console.log(`Inviting owner ${ownerShip} to ${groupId}...`);
+  await inviteGroupMembers({
+    groupId,
+    contactIds: [ownerShip],
+  });
+  console.log(`✅ Owner invited.`);
+
+  await assignOwnerAdminRole(groupId, ownerShip);
+  await verifyOwnerAdmin(groupId, ownerShip);
+
+  console.log(`✅ Owned group created successfully!`);
+  console.log(`   ID: ${groupId}`);
+  console.log(`   Title: ${title}`);
+  console.log(`   Description: ${description || "(none)"}`);
+  console.log(`   Owner: ${ownerShip}`);
+  console.log(`   Channel: ${channelId}`);
+
+  return { groupId, channelId, ownerShip };
 }
 
 // Invite ships to a group
@@ -690,43 +1024,13 @@ async function addChannel(
 // Promote a member to admin by assigning them an admin role
 async function promoteMemberToAdmin(groupId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
-  const group = await getGroup(groupId);
-
-  // Find or create an admin role
-  const adminRole = (group.roles || []).find((r) => r.id === "admin");
-
-  if (!adminRole) {
-    // Create an "admin" role and make it admin
-    console.log(`Creating "admin" role in ${groupId}...`);
-    await addGroupRole({
-      groupId,
-      roleId: "admin",
-      meta: { title: "Admin", description: "Group administrator" },
-    });
-    await poke({
-      app: "groups",
-      mark: "group-action-4",
-      json: {
-        group: {
-          flag: groupId,
-          "a-group": {
-            role: {
-              roles: ["admin"],
-              "a-role": {
-                "set-admin": null,
-              },
-            },
-          },
-        },
-      },
-    });
-  }
+  await ensureAdminRole(groupId);
 
   console.log(`Promoting ${normalizedShips.join(", ")} to admin in ${groupId}...`);
 
   await addMembersToRole({
     groupId,
-    roleId: "admin",
+    roleId: ADMIN_ROLE_ID,
     ships: normalizedShips,
   });
 
@@ -743,11 +1047,11 @@ async function demoteMemberFromAdmin(groupId: string, ships: string[]) {
   const adminRoles = (group.roles || []).filter((r) => {
     // We can't easily tell which roles are admin from the group info alone,
     // so we target the "admin" role specifically
-    return r.id === "admin";
+    return r.id === ADMIN_ROLE_ID;
   });
 
   if (adminRoles.length === 0) {
-    console.error(`No "admin" role found in ${groupId}.`);
+    console.error(`No "${ADMIN_ROLE_ID}" role found in ${groupId}.`);
     process.exit(1);
   }
 
@@ -793,6 +1097,18 @@ async function main() {
       }
       const description = getOption(args, "description") || "";
       await createGroupWithChannel(title, description);
+      break;
+    }
+
+    case "create-owned": {
+      const title = args[1];
+      const owner = getOption(args, "owner");
+      if (!title || !owner || owner.startsWith("--")) {
+        console.error(GROUPS_COMMAND_HELP["create-owned"]);
+        process.exit(1);
+      }
+      const description = getOption(args, "description") || "";
+      await createOwnedGroup(title, owner, description);
       break;
     }
 

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -67,6 +67,7 @@ Examples:
   tlon contacts list
   tlon messages dm ~sampel-palnet --limit 10
   tlon groups create "My Group" --description "A cool group"
+  tlon groups create-owned "My Group" --owner ~zod
   tlon groups join ~host/group-slug
   tlon posts react chat/~host/channel 170.141.184... 👍
   tlon --config ~/ships/zod.json contacts self


### PR DESCRIPTION
## Summary

- Add `tlon groups create-owned "Name" --owner ~ship [--description "..."]`
- Create the group, invite the owner, assign the owner to the admin role, and verify the resulting admin state through raw group data
- Assign admin correctly for both already-joined owners and external owners with pending invites
- Persist group descriptions after creation, covering both `create` and `create-owned`
- Document the new command in the CLI help, README, and skill reference

## Verification

- `bun test`
- `bun build scripts/main.ts --compile --outfile /private/tmp/tlon-skill-tlon-check --define __VERSION__='"0.3.6"'`
- `bun scripts/main.ts groups create-owned --help`
- `git diff --check`
- `./node_modules/.bin/tsc --noEmit 2>&1 | rg 'scripts/groups.ts'`
- Tested in the openclaw-tlon local dev environment.

Related tlonbot PR: https://github.com/tloncorp/tlonbot/pull/88
