### PR TITLE
Fix lockfile sync in version bump flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,6 +1875,18 @@
         "validator": "^13.7.0"
       }
     },
+    "node_modules/@tloncorp/tlon-skill-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@tloncorp/tlon-skill-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@tloncorp/tlon-skill-linux-arm64": {
+      "optional": true
+    },
+    "node_modules/@tloncorp/tlon-skill-linux-x64": {
+      "optional": true
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tloncorp/tlon-skill",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tloncorp/tlon-skill",
-      "version": "0.3.6",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -19,10 +19,10 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@tloncorp/tlon-skill-darwin-arm64": "0.3.6",
-        "@tloncorp/tlon-skill-darwin-x64": "0.3.6",
-        "@tloncorp/tlon-skill-linux-arm64": "0.3.6",
-        "@tloncorp/tlon-skill-linux-x64": "0.3.6"
+        "@tloncorp/tlon-skill-darwin-arm64": "0.4.0",
+        "@tloncorp/tlon-skill-darwin-x64": "0.4.0",
+        "@tloncorp/tlon-skill-linux-arm64": "0.4.0",
+        "@tloncorp/tlon-skill-linux-x64": "0.4.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1873,70 +1873,6 @@
         "lodash": "^4.17.21",
         "sorted-btree": "^1.8.1",
         "validator": "^13.7.0"
-      }
-    },
-    "node_modules/@tloncorp/tlon-skill-darwin-arm64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-arm64/-/tlon-skill-darwin-arm64-0.3.6.tgz",
-      "integrity": "sha512-vR6OeFsIGg9K1QVG2ZZaMC+8QuTyoEp0mGwEJPCooMXF2FxAHTzAE99CNgTmNZbCkCDXIsCL9jMJTcfUNr6xyA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "tlon": "tlon"
-      }
-    },
-    "node_modules/@tloncorp/tlon-skill-darwin-x64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-x64/-/tlon-skill-darwin-x64-0.3.6.tgz",
-      "integrity": "sha512-7A1MLaJ09THCLVOWu/mdzWBDi64md6CLnAlKByduBuza3Osz2VwhJvZb6aVZXQamiKt9vB5yjqPIUvS2AZRhsg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "tlon": "tlon"
-      }
-    },
-    "node_modules/@tloncorp/tlon-skill-linux-arm64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@tloncorp/tlon-skill-linux-arm64/-/tlon-skill-linux-arm64-0.3.6.tgz",
-      "integrity": "sha512-VaMDV78GakJtUNvDF5ItZ1/ahw86hq6UtfCCeTRZU/Rkapluj2XSFI/t4oVxEMNKi9/urRVO3b6V8IklUnRQBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "tlon": "tlon"
-      }
-    },
-    "node_modules/@tloncorp/tlon-skill-linux-x64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@tloncorp/tlon-skill-linux-x64/-/tlon-skill-linux-x64-0.3.6.tgz",
-      "integrity": "sha512-Yp/f6GWuUkNv6k72inX7fY5rf0xxpZpdvmS/U0JWLI5uAk04TiG75ayZIAqJw+Pwp8DRmDGoasH6WfOVjOPHog==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "tlon": "tlon"
       }
     },
     "node_modules/@types/node": {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -20,6 +20,9 @@ const packageFiles = [
   "npm/linux-arm64/package.json",
 ];
 
+const packageLockFile = "package-lock.json";
+const tlonSkillPackagePrefix = "@tloncorp/tlon-skill-";
+
 const newVersion = process.argv[2];
 
 if (!newVersion) {
@@ -40,6 +43,18 @@ if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
 
 console.log(`Bumping version to ${newVersion}...\n`);
 
+function updateTlonSkillOptionalDeps(optionalDependencies) {
+  if (!optionalDependencies) {
+    return;
+  }
+
+  for (const dep of Object.keys(optionalDependencies)) {
+    if (dep.startsWith(tlonSkillPackagePrefix)) {
+      optionalDependencies[dep] = newVersion;
+    }
+  }
+}
+
 for (const file of packageFiles) {
   const filePath = join(rootDir, file);
   try {
@@ -48,12 +63,8 @@ for (const file of packageFiles) {
     pkg.version = newVersion;
 
     // Also update optionalDependencies versions in main package.json
-    if (file === "package.json" && pkg.optionalDependencies) {
-      for (const dep of Object.keys(pkg.optionalDependencies)) {
-        if (dep.startsWith("@tloncorp/tlon-skill-")) {
-          pkg.optionalDependencies[dep] = newVersion;
-        }
-      }
+    if (file === "package.json") {
+      updateTlonSkillOptionalDeps(pkg.optionalDependencies);
     }
 
     writeFileSync(filePath, JSON.stringify(pkg, null, 2) + "\n");
@@ -61,6 +72,34 @@ for (const file of packageFiles) {
   } catch (err) {
     console.error(`  ${file}: ERROR - ${err.message}`);
   }
+}
+
+try {
+  const filePath = join(rootDir, packageLockFile);
+  const packageLock = JSON.parse(readFileSync(filePath, "utf-8"));
+  const oldVersion = packageLock.version;
+  packageLock.version = newVersion;
+
+  const rootPackage = packageLock.packages?.[""];
+  if (rootPackage) {
+    rootPackage.version = newVersion;
+    updateTlonSkillOptionalDeps(rootPackage.optionalDependencies);
+  }
+
+  if (packageLock.packages) {
+    // The platform packages are published after the bump PR is merged.
+    // Drop stale tarball entries instead of carrying lock entries for the old release.
+    for (const packagePath of Object.keys(packageLock.packages)) {
+      if (packagePath.startsWith(`node_modules/${tlonSkillPackagePrefix}`)) {
+        delete packageLock.packages[packagePath];
+      }
+    }
+  }
+
+  writeFileSync(filePath, JSON.stringify(packageLock, null, 2) + "\n");
+  console.log(`  ${packageLockFile}: ${oldVersion} → ${newVersion}`);
+} catch (err) {
+  console.error(`  ${packageLockFile}: ERROR - ${err.message}`);
 }
 
 console.log("\nDone! Don't forget to:");

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -43,15 +43,19 @@ if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
 
 console.log(`Bumping version to ${newVersion}...\n`);
 
-function updateTlonSkillOptionalDeps(optionalDependencies) {
+function getTlonSkillOptionalDeps(optionalDependencies) {
   if (!optionalDependencies) {
-    return;
+    return [];
   }
 
-  for (const dep of Object.keys(optionalDependencies)) {
-    if (dep.startsWith(tlonSkillPackagePrefix)) {
-      optionalDependencies[dep] = newVersion;
-    }
+  return Object.keys(optionalDependencies).filter((dep) =>
+    dep.startsWith(tlonSkillPackagePrefix)
+  );
+}
+
+function updateTlonSkillOptionalDeps(optionalDependencies) {
+  for (const dep of getTlonSkillOptionalDeps(optionalDependencies)) {
+    optionalDependencies[dep] = newVersion;
   }
 }
 
@@ -87,12 +91,26 @@ try {
   }
 
   if (packageLock.packages) {
-    // The platform packages are published after the bump PR is merged.
-    // Drop stale tarball entries instead of carrying lock entries for the old release.
+    const platformPackagePaths = new Set(
+      getTlonSkillOptionalDeps(rootPackage?.optionalDependencies).map(
+        (dep) => `node_modules/${dep}`
+      )
+    );
+
     for (const packagePath of Object.keys(packageLock.packages)) {
       if (packagePath.startsWith(`node_modules/${tlonSkillPackagePrefix}`)) {
-        delete packageLock.packages[packagePath];
+        if (platformPackagePaths.has(packagePath)) {
+          packageLock.packages[packagePath] = { optional: true };
+        } else {
+          delete packageLock.packages[packagePath];
+        }
       }
+    }
+
+    // npm 11 requires lock entries for optional deps. These packages publish
+    // after the bump PR merges, so use placeholders instead of old tarballs.
+    for (const packagePath of platformPackagePaths) {
+      packageLock.packages[packagePath] = { optional: true };
     }
   }
 


### PR DESCRIPTION
## Summary

- Sync `package-lock.json` with the merged `0.4.0` version bump
- Replace stale platform package tarball entries with npm 11-compatible optional placeholders
- Update the version bump script so future release PRs keep `package-lock.json` in sync without carrying old platform package tarballs

## Testing

- `node scripts/bump-version.js 0.4.0`
- `npm ci --ignore-scripts --dry-run --fetch-retries=0 --fetch-timeout=5000`
- `npx npm@11 ci --ignore-scripts --dry-run --fetch-retries=0 --fetch-timeout=5000`
- `npm test`
- `git diff --check`