### PR TITLE
Normalize no-config CLI help and usage errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ npm install @tloncorp/tlon-skill
 **Direct download (no Node required):**
 ```bash
 # macOS ARM64
-curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-arm64/-/tlon-skill-darwin-arm64-0.1.0.tgz | tar -xz
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-arm64/-/tlon-skill-darwin-arm64-0.4.0.tgz | tar -xz
 mv package/tlon /usr/local/bin/
 
 # macOS x64
-curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-x64/-/tlon-skill-darwin-x64-0.1.0.tgz | tar -xz
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-x64/-/tlon-skill-darwin-x64-0.4.0.tgz | tar -xz
 
 # Linux x64
-curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-linux-x64/-/tlon-skill-linux-x64-0.1.0.tgz | tar -xz
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-linux-x64/-/tlon-skill-linux-x64-0.4.0.tgz | tar -xz
+
+# Linux ARM64
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-linux-arm64/-/tlon-skill-linux-arm64-0.4.0.tgz | tar -xz
 ```
 
 ## Configuration
@@ -143,10 +146,25 @@ tlon groups reject-invite ~host/group-slug
 - **Groups**: Create, join, invite/request flows, roles, privacy (member nicknames shown)
 - **Hooks**: Manage channel hooks (add, edit, delete, order, config, cron)
 - **Messages**: History, search (author nicknames shown)
-- **DMs**: Send, react, accept/decline
-- **Posts**: React, delete
+- **DMs**: Group DM send/reply, react, accept/decline
+- **Posts**: React, edit, delete
 - **Notebook**: Post to diary channels
 - **Settings**: Hot-reload plugin config via settings-store
+
+## Development
+
+Use the Node version in `.tool-versions` and Bun `1.3.4`.
+
+```bash
+npm ci
+npm run typecheck
+npm run test:unit
+npm run test:integration
+npm run build:smoke
+npm run check
+```
+
+`npm run check` is the main local quality gate and is also run by CI. Coverage reporting is available with `npm run test:coverage`.
 
 ## Documentation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -47,11 +47,11 @@ tlon channels groups
 **Direct binary (no Node required):**
 
 ```bash
-curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-arm64/-/tlon-skill-darwin-arm64-0.1.0.tgz | tar -xz
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-arm64/-/tlon-skill-darwin-arm64-0.4.0.tgz | tar -xz
 ./package/tlon channels groups
 ```
 
-Replace `darwin-arm64` with `darwin-x64` or `linux-x64` as needed.
+Replace `darwin-arm64` with `darwin-x64`, `linux-x64`, or `linux-arm64` as needed.
 
 ## Configuration
 
@@ -143,9 +143,9 @@ If you have credentials for multiple ships, you can use this skill to operate on
 Simply pass the target ship's credentials via CLI flags:
 
 ```bash
-# Post to a channel as ~other-ship
+# Read channels as ~other-ship
 tlon --url https://other-ship.tlon.network --ship ~other-ship --code their-access-code \
-  posts send chat/~host/channel "Hello from other-ship"
+  channels groups
 
 # Or keep credentials in config files
 tlon --config ~/ships/bot.json channels groups
@@ -153,6 +153,8 @@ tlon --config ~/ships/moon.json contacts self
 ```
 
 ## Commands
+
+Help and usage errors are handled locally before credential lookup, so `tlon <command> --help` works without a configured ship.
 
 ### Activity
 

--- a/scripts/activity.ts
+++ b/scripts/activity.ts
@@ -11,6 +11,7 @@
 
 import { getInitialActivity, getGroupAndChannelUnreads, getTextContent } from "@tloncorp/api";
 import { ensureClient } from "./api-client";
+import { isHelpArg, printErrorAndExit, printHelpAndExit, printUsageAndExit } from "./cli-utils";
 
 interface ActivityEvent {
   id: string;
@@ -33,17 +34,13 @@ interface ActivityEvent {
   contactUpdateValue?: string | null;
 }
 
-const ACTIVITY_HELP = `Usage: activity <command>
+const ACTIVITY_HELP = `Usage: tlon activity <command>
 
 Commands:
   mentions [--limit N]   Show mention activity
   replies [--limit N]    Show reply activity
   all [--limit N]        Show all activity
   unreads                Show unread counts`;
-
-function printHelp() {
-  console.log(ACTIVITY_HELP);
-}
 
 // Extract text content from a Story (which is actually an array of blocks)
 function extractText(content: any): string {
@@ -225,14 +222,16 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
-  if (command === "--help" || command === "-h") {
-    printHelp();
-    process.exit(0);
+  if (isHelpArg(command)) {
+    printHelpAndExit(ACTIVITY_HELP);
   }
 
   if (!command) {
-    printHelp();
-    process.exit(1);
+    printUsageAndExit(ACTIVITY_HELP);
+  }
+
+  if (!["mentions", "replies", "all", "unreads"].includes(command)) {
+    printUsageAndExit(ACTIVITY_HELP);
   }
 
   await ensureClient();
@@ -257,11 +256,8 @@ async function main() {
     case 'unreads':
       await getUnreads();
       break;
-    default:
-      printHelp();
-      process.exit(1);
   }
   process.exit(0);
 }
 
-main().catch(console.error);
+main().catch(printErrorAndExit);

--- a/scripts/activity.ts
+++ b/scripts/activity.ts
@@ -217,6 +217,19 @@ async function getUnreads() {
   }
 }
 
+const ACTIVITY_HANDLERS = {
+  mentions: (limit: number) => getActivity("mentions", limit),
+  replies: (limit: number) => getActivity("replies", limit),
+  all: (limit: number) => getActivity("all", limit),
+  unreads: (_limit: number) => getUnreads(),
+} satisfies Record<string, (limit: number) => Promise<void>>;
+
+type ActivityCommand = keyof typeof ACTIVITY_HANDLERS;
+
+function isActivityCommand(command: string): command is ActivityCommand {
+  return Object.prototype.hasOwnProperty.call(ACTIVITY_HANDLERS, command);
+}
+
 // Main
 async function main() {
   const args = process.argv.slice(2);
@@ -230,7 +243,7 @@ async function main() {
     printUsageAndExit(ACTIVITY_HELP);
   }
 
-  if (!["mentions", "replies", "all", "unreads"].includes(command)) {
+  if (!isActivityCommand(command)) {
     printUsageAndExit(ACTIVITY_HELP);
   }
 
@@ -243,20 +256,7 @@ async function main() {
     limit = parseInt(args[limitIdx + 1], 10);
   }
   
-  switch (command) {
-    case 'mentions':
-      await getActivity('mentions', limit);
-      break;
-    case 'replies':
-      await getActivity('replies', limit);
-      break;
-    case 'all':
-      await getActivity('all', limit);
-      break;
-    case 'unreads':
-      await getUnreads();
-      break;
-  }
+  await ACTIVITY_HANDLERS[command](limit);
   process.exit(0);
 }
 

--- a/scripts/build-smoke.ts
+++ b/scripts/build-smoke.ts
@@ -133,6 +133,32 @@ for (const testCase of CLI_MATRIX_CASES) {
   assertCase(testCase);
 }
 
+const literalHelpMessageCommands = [
+  {
+    name: "dms send message",
+    args: ["dms", "send", "0v123", "use", "--help"],
+  },
+  {
+    name: "dms reply message",
+    args: ["dms", "reply", "0v123", "~zod/170.141", "use", "--help"],
+  },
+  {
+    name: "posts edit message",
+    args: ["posts", "edit", "chat/~host/channel", "170.141", "use", "--help"],
+  },
+];
+
+for (const command of literalHelpMessageCommands) {
+  assertCase({
+    name: `${command.name} literal --help reaches auth`,
+    args: command.args,
+    expectedExitCode: 1,
+    stdout: "",
+    stderrIncludes: ["Missing Urbit config"],
+    stderrExcludes: ["Usage:"],
+  });
+}
+
 const hostileHelpCommands = [
   { name: "top-level", args: ["--help"] },
   ...COMMAND_FAMILIES.map((family) => ({

--- a/scripts/build-smoke.ts
+++ b/scripts/build-smoke.ts
@@ -133,7 +133,7 @@ for (const testCase of CLI_MATRIX_CASES) {
   assertCase(testCase);
 }
 
-const literalHelpMessageCommands = [
+const literalOptionLikeValueCommands = [
   {
     name: "dms send message",
     args: ["dms", "send", "0v123", "use", "--help"],
@@ -146,11 +146,27 @@ const literalHelpMessageCommands = [
     name: "posts edit message",
     args: ["posts", "edit", "chat/~host/channel", "170.141", "use", "--help"],
   },
+  {
+    name: "contacts update-profile value",
+    args: ["contacts", "update-profile", "--status", "--help"],
+  },
+  {
+    name: "contacts update value",
+    args: ["contacts", "update", "~zod", "--nickname", "-h"],
+  },
+  {
+    name: "channels create title",
+    args: ["channels", "create", "~host/group", "--roadmap"],
+  },
+  {
+    name: "channels rename title",
+    args: ["channels", "rename", "chat/~host/channel", "--roadmap"],
+  },
 ];
 
-for (const command of literalHelpMessageCommands) {
+for (const command of literalOptionLikeValueCommands) {
   assertCase({
-    name: `${command.name} literal --help reaches auth`,
+    name: `${command.name} option-like value reaches auth`,
     args: command.args,
     expectedExitCode: 1,
     stdout: "",

--- a/scripts/build-smoke.ts
+++ b/scripts/build-smoke.ts
@@ -142,7 +142,7 @@ const hostileHelpCommands = [
 ];
 
 for (const command of hostileHelpCommands) {
-  const configPath = join("/nonexistent", `${command.name}-ship.json`);
+  const configPath = join(tmpdir(), "tlon-missing-config", `${command.name}-ship.json`);
 
   assertCase(
     {

--- a/scripts/build-smoke.ts
+++ b/scripts/build-smoke.ts
@@ -19,6 +19,10 @@ const packageJson = JSON.parse(
 type RunOptions = {
   argsPrefix?: string[];
   env?: Record<string, string>;
+  prepare?: (tempRoot: string) => {
+    argsPrefix?: string[];
+    env?: Record<string, string>;
+  } | void;
 };
 
 type CliResult = {
@@ -54,9 +58,15 @@ function fail(message: string): never {
 function runBuiltCli(args: string[], options: RunOptions = {}): CliResult {
   const tempRoot = mkdtempSync(join(tmpdir(), "tlon-build-smoke-"));
   try {
-    const result = spawnSync(binaryPath, [...(options.argsPrefix ?? []), ...args], {
+    const prepared = options.prepare?.(tempRoot) ?? {};
+    const argsPrefix = prepared.argsPrefix ?? options.argsPrefix ?? [];
+    const env = {
+      ...(options.env ?? {}),
+      ...(prepared.env ?? {}),
+    };
+    const result = spawnSync(binaryPath, [...argsPrefix, ...args], {
       cwd: rootDir,
-      env: hermeticEnv(tempRoot, options.env),
+      env: hermeticEnv(tempRoot, env),
       encoding: "utf-8",
       timeout: SMOKE_TIMEOUT_MS,
     });
@@ -133,96 +143,6 @@ for (const testCase of CLI_MATRIX_CASES) {
   assertCase(testCase);
 }
 
-const literalOptionLikeValueCommands = [
-  {
-    name: "dms send message",
-    args: ["dms", "send", "0v123", "use", "--help"],
-  },
-  {
-    name: "dms reply message",
-    args: ["dms", "reply", "0v123", "~zod/170.141", "use", "--help"],
-  },
-  {
-    name: "posts edit message",
-    args: ["posts", "edit", "chat/~host/channel", "170.141", "use", "--help"],
-  },
-  {
-    name: "messages search query",
-    args: ["messages", "search", "--channel", "--channel", "chat/~host/channel"],
-  },
-  {
-    name: "contacts update-profile value",
-    args: ["contacts", "update-profile", "--status", "--help"],
-  },
-  {
-    name: "contacts update value",
-    args: ["contacts", "update", "~zod", "--nickname", "-h"],
-  },
-  {
-    name: "channels create title",
-    args: ["channels", "create", "~host/group", "--roadmap"],
-  },
-  {
-    name: "channels rename title",
-    args: ["channels", "rename", "chat/~host/channel", "--roadmap"],
-  },
-  {
-    name: "channels update title",
-    args: ["channels", "update", "chat/~host/channel", "--title", "--help"],
-  },
-  {
-    name: "groups create title",
-    args: ["groups", "create", "--roadmap"],
-  },
-  {
-    name: "groups create-owned title",
-    args: ["groups", "create-owned", "--roadmap", "--owner", "~zod"],
-  },
-  {
-    name: "groups update title",
-    args: ["groups", "update", "~host/group", "--title", "--help"],
-  },
-  {
-    name: "groups add-channel title",
-    args: ["groups", "add-channel", "~host/group", "--announcements"],
-  },
-  {
-    name: "hooks edit name",
-    args: ["hooks", "edit", "0v1a", "--name", "--help"],
-  },
-  {
-    name: "notebook title",
-    args: ["notebook", "diary/~host/notes", "--help"],
-  },
-  {
-    name: "contacts update-profile empty value",
-    args: ["contacts", "update-profile", "--status", ""],
-  },
-  {
-    name: "contacts update empty value",
-    args: ["contacts", "update", "~zod", "--nickname", ""],
-  },
-  {
-    name: "channels update empty value",
-    args: ["channels", "update", "chat/~host/channel", "--description", ""],
-  },
-  {
-    name: "groups update empty value",
-    args: ["groups", "update", "~host/group", "--description", ""],
-  },
-];
-
-for (const command of literalOptionLikeValueCommands) {
-  assertCase({
-    name: `${command.name} option-like value reaches auth`,
-    args: command.args,
-    expectedExitCode: 1,
-    stdoutExcludes: ["Usage:"],
-    stderrIncludes: ["Missing Urbit config"],
-    stderrExcludes: ["Usage:"],
-  });
-}
-
 const hostileHelpCommands = [
   { name: "top-level", args: ["--help"] },
   ...COMMAND_FAMILIES.map((family) => ({
@@ -232,8 +152,6 @@ const hostileHelpCommands = [
 ];
 
 for (const command of hostileHelpCommands) {
-  const configPath = join(tmpdir(), "tlon-missing-config", `${command.name}-ship.json`);
-
   assertCase(
     {
       name: `${command.name} help with nonexistent TLON_CONFIG_FILE`,
@@ -242,14 +160,27 @@ for (const command of hostileHelpCommands) {
       stderr: "",
       stdoutIncludes: ["Usage:"],
     },
-    { env: { TLON_CONFIG_FILE: configPath } }
+    {
+      prepare: (tempRoot) => ({
+        env: {
+          TLON_CONFIG_FILE: join(tempRoot, `${command.name}-ship.json`),
+        },
+      }),
+    }
   );
 
-  assertCase({
-    name: `${command.name} help with CLI --config /nonexistent`,
-    args: ["--config", configPath, ...command.args],
-    expectedExitCode: 0,
-    stderr: "",
-    stdoutIncludes: ["Usage:"],
-  });
+  assertCase(
+    {
+      name: `${command.name} help with CLI --config /nonexistent`,
+      args: command.args,
+      expectedExitCode: 0,
+      stderr: "",
+      stdoutIncludes: ["Usage:"],
+    },
+    {
+      prepare: (tempRoot) => ({
+        argsPrefix: ["--config", join(tempRoot, `${command.name}-ship.json`)],
+      }),
+    }
+  );
 }

--- a/scripts/build-smoke.ts
+++ b/scripts/build-smoke.ts
@@ -162,6 +162,34 @@ const literalOptionLikeValueCommands = [
     name: "channels rename title",
     args: ["channels", "rename", "chat/~host/channel", "--roadmap"],
   },
+  {
+    name: "channels update title",
+    args: ["channels", "update", "chat/~host/channel", "--title", "--help"],
+  },
+  {
+    name: "groups create title",
+    args: ["groups", "create", "--roadmap"],
+  },
+  {
+    name: "groups create-owned title",
+    args: ["groups", "create-owned", "--roadmap", "--owner", "~zod"],
+  },
+  {
+    name: "groups update title",
+    args: ["groups", "update", "~host/group", "--title", "--help"],
+  },
+  {
+    name: "groups add-channel title",
+    args: ["groups", "add-channel", "~host/group", "--announcements"],
+  },
+  {
+    name: "hooks edit name",
+    args: ["hooks", "edit", "0v1a", "--name", "--help"],
+  },
+  {
+    name: "notebook title",
+    args: ["notebook", "diary/~host/notes", "--help"],
+  },
 ];
 
 for (const command of literalOptionLikeValueCommands) {
@@ -169,7 +197,7 @@ for (const command of literalOptionLikeValueCommands) {
     name: `${command.name} option-like value reaches auth`,
     args: command.args,
     expectedExitCode: 1,
-    stdout: "",
+    stdoutExcludes: ["Usage:"],
     stderrIncludes: ["Missing Urbit config"],
     stderrExcludes: ["Usage:"],
   });

--- a/scripts/build-smoke.ts
+++ b/scripts/build-smoke.ts
@@ -147,6 +147,10 @@ const literalOptionLikeValueCommands = [
     args: ["posts", "edit", "chat/~host/channel", "170.141", "use", "--help"],
   },
   {
+    name: "messages search query",
+    args: ["messages", "search", "--channel", "--channel", "chat/~host/channel"],
+  },
+  {
     name: "contacts update-profile value",
     args: ["contacts", "update-profile", "--status", "--help"],
   },
@@ -189,6 +193,22 @@ const literalOptionLikeValueCommands = [
   {
     name: "notebook title",
     args: ["notebook", "diary/~host/notes", "--help"],
+  },
+  {
+    name: "contacts update-profile empty value",
+    args: ["contacts", "update-profile", "--status", ""],
+  },
+  {
+    name: "contacts update empty value",
+    args: ["contacts", "update", "~zod", "--nickname", ""],
+  },
+  {
+    name: "channels update empty value",
+    args: ["channels", "update", "chat/~host/channel", "--description", ""],
+  },
+  {
+    name: "groups update empty value",
+    args: ["groups", "update", "~host/group", "--description", ""],
   },
 ];
 

--- a/scripts/build-smoke.ts
+++ b/scripts/build-smoke.ts
@@ -1,7 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import {
+  CLI_MATRIX_CASES,
+  COMMAND_FAMILIES,
+  type CliCase,
+  normalizeCliOutput,
+} from "./cli-test-matrix";
 
 const rootDir = resolve(process.cwd());
 const binaryPath = join(rootDir, "dist", "tlon-run");
@@ -10,35 +16,22 @@ const packageJson = JSON.parse(
   readFileSync(join(rootDir, "package.json"), "utf-8")
 ) as { version: string };
 
-type SmokeCase = {
-  name: string;
-  args: string[];
-  expectedStdout?: string;
-  stdoutIncludes?: string;
+type RunOptions = {
+  argsPrefix?: string[];
+  env?: Record<string, string>;
 };
 
-function hermeticEnv(tempRoot: string): Record<string, string> {
+type CliResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+function hermeticEnv(tempRoot: string, extraEnv: Record<string, string> = {}): Record<string, string> {
   const home = join(tempRoot, "home");
   const cacheDir = join(tempRoot, "cache");
   mkdirSync(home);
   mkdirSync(cacheDir);
-
-  writeFileSync(
-    join(cacheDir, "zod.json"),
-    JSON.stringify({
-      url: "https://zod.example",
-      ship: "zod",
-      cookie: "urbauth-~zod=fake",
-    })
-  );
-  writeFileSync(
-    join(cacheDir, "bus.json"),
-    JSON.stringify({
-      url: "https://bus.example",
-      ship: "bus",
-      cookie: "urbauth-~bus=fake",
-    })
-  );
 
   const env: Record<string, string> = {};
   for (const key of ["PATH", "SystemRoot", "WINDIR"]) {
@@ -50,8 +43,7 @@ function hermeticEnv(tempRoot: string): Record<string, string> {
   env.HOME = home;
   env.TLON_CACHE_DIR = cacheDir;
   env.OPENCLAW_CONFIG = join(home, "missing-openclaw.json");
-  env.TLON_CONFIG_FILE = join(home, "missing-ship.json");
-  return env;
+  return { ...env, ...extraEnv };
 }
 
 function fail(message: string): never {
@@ -59,66 +51,115 @@ function fail(message: string): never {
   process.exit(1);
 }
 
-function assertSmokeCase(testCase: SmokeCase): void {
+function runBuiltCli(args: string[], options: RunOptions = {}): CliResult {
   const tempRoot = mkdtempSync(join(tmpdir(), "tlon-build-smoke-"));
   try {
-    const result = spawnSync(binaryPath, testCase.args, {
+    const result = spawnSync(binaryPath, [...(options.argsPrefix ?? []), ...args], {
       cwd: rootDir,
-      env: hermeticEnv(tempRoot),
+      env: hermeticEnv(tempRoot, options.env),
       encoding: "utf-8",
       timeout: SMOKE_TIMEOUT_MS,
     });
 
     if (result.error) {
-      fail(`${testCase.name}: failed to run binary: ${result.error.message}`);
-    }
-    if (result.status !== 0) {
-      fail(
-        `${testCase.name}: expected exit 0, got ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
-      );
-    }
-    if (result.stderr !== "") {
-      fail(`${testCase.name}: expected empty stderr, got:\n${result.stderr}`);
-    }
-    if (
-      testCase.expectedStdout !== undefined &&
-      result.stdout !== testCase.expectedStdout
-    ) {
-      fail(
-        `${testCase.name}: unexpected stdout\nexpected:\n${testCase.expectedStdout}\nactual:\n${result.stdout}`
-      );
-    }
-    if (
-      testCase.stdoutIncludes !== undefined &&
-      !result.stdout.includes(testCase.stdoutIncludes)
-    ) {
-      fail(
-        `${testCase.name}: stdout did not include ${JSON.stringify(testCase.stdoutIncludes)}\nstdout:\n${result.stdout}`
-      );
+      fail(`failed to run binary: ${result.error.message}`);
     }
 
-    console.log(`ok - ${testCase.name}`);
+    return {
+      exitCode: result.status ?? 1,
+      stdout: normalizeCliOutput(result.stdout),
+      stderr: normalizeCliOutput(result.stderr),
+    };
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }
 }
 
-for (const testCase of [
-  {
-    name: "tlon-run --version",
-    args: ["--version"],
-    expectedStdout: `${packageJson.version}\n`,
-  },
-  {
-    name: "tlon-run upload --help",
-    args: ["upload", "--help"],
-    stdoutIncludes: "Usage: upload",
-  },
-  {
-    name: "tlon-run activity --help",
-    args: ["activity", "--help"],
-    stdoutIncludes: "Usage: activity",
-  },
-] satisfies SmokeCase[]) {
-  assertSmokeCase(testCase);
+function assertCliCase(testCase: CliCase, result: CliResult): void {
+  if (result.exitCode !== testCase.expectedExitCode) {
+    fail(
+      `${testCase.name}: expected exit ${testCase.expectedExitCode}, got ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+
+  if (testCase.stdout !== undefined && result.stdout !== testCase.stdout) {
+    fail(
+      `${testCase.name}: unexpected stdout\nexpected:\n${testCase.stdout}\nactual:\n${result.stdout}`
+    );
+  }
+  for (const expected of testCase.stdoutIncludes ?? []) {
+    if (!result.stdout.includes(expected)) {
+      fail(`${testCase.name}: stdout did not include ${JSON.stringify(expected)}\nstdout:\n${result.stdout}`);
+    }
+  }
+  for (const unexpected of testCase.stdoutExcludes ?? []) {
+    if (result.stdout.includes(unexpected)) {
+      fail(`${testCase.name}: stdout included ${JSON.stringify(unexpected)}\nstdout:\n${result.stdout}`);
+    }
+  }
+
+  if (testCase.stderr !== undefined && result.stderr !== testCase.stderr) {
+    fail(
+      `${testCase.name}: unexpected stderr\nexpected:\n${testCase.stderr}\nactual:\n${result.stderr}`
+    );
+  }
+  for (const expected of testCase.stderrIncludes ?? []) {
+    if (!result.stderr.includes(expected)) {
+      fail(`${testCase.name}: stderr did not include ${JSON.stringify(expected)}\nstderr:\n${result.stderr}`);
+    }
+  }
+  for (const unexpected of testCase.stderrExcludes ?? []) {
+    if (result.stderr.includes(unexpected)) {
+      fail(`${testCase.name}: stderr included ${JSON.stringify(unexpected)}\nstderr:\n${result.stderr}`);
+    }
+  }
+}
+
+function assertCase(testCase: CliCase, options: RunOptions = {}): void {
+  const result = runBuiltCli(testCase.args, options);
+  assertCliCase(testCase, result);
+  console.log(`ok - ${testCase.name}`);
+}
+
+assertCase({
+  name: "tlon-run --version",
+  args: ["--version"],
+  expectedExitCode: 0,
+  stdout: `${packageJson.version}\n`,
+  stderr: "",
+});
+
+for (const testCase of CLI_MATRIX_CASES) {
+  assertCase(testCase);
+}
+
+const hostileHelpCommands = [
+  { name: "top-level", args: ["--help"] },
+  ...COMMAND_FAMILIES.map((family) => ({
+    name: family,
+    args: [family, "--help"],
+  })),
+];
+
+for (const command of hostileHelpCommands) {
+  const configPath = join("/nonexistent", `${command.name}-ship.json`);
+
+  assertCase(
+    {
+      name: `${command.name} help with nonexistent TLON_CONFIG_FILE`,
+      args: command.args,
+      expectedExitCode: 0,
+      stderr: "",
+      stdoutIncludes: ["Usage:"],
+    },
+    { env: { TLON_CONFIG_FILE: configPath } }
+  );
+
+  assertCase({
+    name: `${command.name} help with CLI --config /nonexistent`,
+    args: ["--config", configPath, ...command.args],
+    expectedExitCode: 0,
+    stderr: "",
+    stdoutIncludes: ["Usage:"],
+  });
 }

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -88,6 +88,8 @@ const CHANNELS_COMMAND_HELP: Record<string, string> = {
   "del-readers": `Usage: tlon channels del-readers <group-flag> <nest> <role1> [role2...]\nExample: tlon channels del-readers ~host/group-slug chat/~host/slug admin`,
 };
 
+const CHANNEL_UPDATE_FLAGS = ["title", "description"] as const;
+
 function getChannelsHelp(command?: string) {
   return command ? CHANNELS_COMMAND_HELP[command] ?? CHANNELS_HELP : CHANNELS_HELP;
 }
@@ -122,7 +124,11 @@ function validateChannelsArgs(args: string[]): void {
     }
     case "update": {
       if (!args[1]) printUsageAndExit(CHANNELS_COMMAND_HELP.update);
-      if (!hasOptionValue(args, "title") && !hasOptionValue(args, "description")) {
+      if (
+        !CHANNEL_UPDATE_FLAGS.some((flag) =>
+          hasOptionValue(args, flag, CHANNEL_UPDATE_FLAGS)
+        )
+      ) {
         printUsageAndExit(
           `Error: At least one of --title or --description is required\n${CHANNELS_COMMAND_HELP.update}`
         );

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -32,6 +32,7 @@ import type { Channel as ApiChannel, Group as ApiGroup } from "@tloncorp/api";
 import { ensureClient, getCurrentShip } from "./api-client";
 import {
   getOption,
+  hasOptionValue,
   isHelpArg,
   looksLikePositionalChannelKind,
   printErrorAndExit,
@@ -59,7 +60,7 @@ Commands:
   all
   info <nest>
   create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]
-  update <nest> --title "..." [--description "..."]
+  update <nest> (--title "..." | --description "...")
   rename <nest> "New Title"
   delete <nest>
   add-writers <nest> <role1> [role2...]
@@ -78,7 +79,7 @@ const CHANNELS_COMMAND_HELP: Record<string, string> = {
   all: `Usage: tlon channels all`,
   info: `Usage: tlon channels info <nest>\nExample: tlon channels info chat/~host/slug`,
   create: `Usage: tlon channels create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]\nExample: tlon channels create ~host/group-slug "Projects" --kind chat`,
-  update: `Usage: tlon channels update <nest> --title "..." [--description "..."]\nExample: tlon channels update chat/~host/slug --title "New Title"`,
+  update: `Usage: tlon channels update <nest> (--title "..." | --description "...")\nExample: tlon channels update chat/~host/slug --title "New Title"`,
   rename: `Usage: tlon channels rename <nest> "New Title"\nExample: tlon channels rename chat/~host/slug "Project Updates"`,
   delete: `Usage: tlon channels delete <nest>\nExample: tlon channels delete chat/~host/slug`,
   "add-writers": `Usage: tlon channels add-writers <nest> <role1> [role2...]\nExample: tlon channels add-writers chat/~host/slug admin`,
@@ -121,7 +122,7 @@ function validateChannelsArgs(args: string[]): void {
     }
     case "update": {
       if (!args[1]) printUsageAndExit(CHANNELS_COMMAND_HELP.update);
-      if (!getOption(args, "title") && !getOption(args, "description")) {
+      if (!hasOptionValue(args, "title") && !hasOptionValue(args, "description")) {
         printUsageAndExit(
           `Error: At least one of --title or --description is required\n${CHANNELS_COMMAND_HELP.update}`
         );

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -38,7 +38,6 @@ import {
   printErrorAndExit,
   printHelpAndExit,
   printUsageAndExit,
-  wantsHelp,
 } from "./cli-utils";
 
 function generateChannelSlug(): string {
@@ -97,6 +96,10 @@ function getChannelsHelp(command?: string) {
 
 function isKnownChannelCreateOption(arg: string | undefined): boolean {
   return CHANNEL_CREATE_FLAGS.some((flag) => arg === `--${flag}`);
+}
+
+function isChannelsHelpRequest(args: string[]): boolean {
+  return args.length === 2 && isHelpArg(args[1]);
 }
 
 function validateChannelsArgs(args: string[]): void {
@@ -479,7 +482,7 @@ async function main() {
     printHelpAndExit(CHANNELS_HELP);
   }
 
-  if (wantsHelp(args.slice(1))) {
+  if (isChannelsHelpRequest(args)) {
     printHelpAndExit(getChannelsHelp(command));
   }
 

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -88,10 +88,15 @@ const CHANNELS_COMMAND_HELP: Record<string, string> = {
   "del-readers": `Usage: tlon channels del-readers <group-flag> <nest> <role1> [role2...]\nExample: tlon channels del-readers ~host/group-slug chat/~host/slug admin`,
 };
 
+const CHANNEL_CREATE_FLAGS = ["kind", "description"] as const;
 const CHANNEL_UPDATE_FLAGS = ["title", "description"] as const;
 
 function getChannelsHelp(command?: string) {
   return command ? CHANNELS_COMMAND_HELP[command] ?? CHANNELS_HELP : CHANNELS_HELP;
+}
+
+function isKnownChannelCreateOption(arg: string | undefined): boolean {
+  return CHANNEL_CREATE_FLAGS.some((flag) => arg === `--${flag}`);
 }
 
 function validateChannelsArgs(args: string[]): void {
@@ -112,7 +117,7 @@ function validateChannelsArgs(args: string[]): void {
       return;
     }
     case "create": {
-      if (!args[1] || !args[2] || args[2].startsWith("--")) {
+      if (!args[1] || !args[2] || isKnownChannelCreateOption(args[2])) {
         printUsageAndExit(CHANNELS_COMMAND_HELP.create);
       }
       if (looksLikePositionalChannelKind(args, 2)) {
@@ -136,7 +141,7 @@ function validateChannelsArgs(args: string[]): void {
       return;
     }
     case "rename": {
-      if (!args[1] || !args[2] || args[2].startsWith("--")) {
+      if (!args[1] || !args[2]) {
         printUsageAndExit(CHANNELS_COMMAND_HELP.rename);
       }
       return;

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -34,6 +34,7 @@ import {
   getOption,
   hasOptionValue,
   isHelpArg,
+  isSubcommandHelpRequest,
   looksLikePositionalChannelKind,
   printErrorAndExit,
   printHelpAndExit,
@@ -87,19 +88,10 @@ const CHANNELS_COMMAND_HELP: Record<string, string> = {
   "del-readers": `Usage: tlon channels del-readers <group-flag> <nest> <role1> [role2...]\nExample: tlon channels del-readers ~host/group-slug chat/~host/slug admin`,
 };
 
-const CHANNEL_CREATE_FLAGS = ["kind", "description"] as const;
 const CHANNEL_UPDATE_FLAGS = ["title", "description"] as const;
 
 function getChannelsHelp(command?: string) {
   return command ? CHANNELS_COMMAND_HELP[command] ?? CHANNELS_HELP : CHANNELS_HELP;
-}
-
-function isKnownChannelCreateOption(arg: string | undefined): boolean {
-  return CHANNEL_CREATE_FLAGS.some((flag) => arg === `--${flag}`);
-}
-
-function isChannelsHelpRequest(args: string[]): boolean {
-  return args.length === 2 && isHelpArg(args[1]);
 }
 
 function validateChannelsArgs(args: string[]): void {
@@ -120,7 +112,7 @@ function validateChannelsArgs(args: string[]): void {
       return;
     }
     case "create": {
-      if (!args[1] || !args[2] || isKnownChannelCreateOption(args[2])) {
+      if (!args[1] || args[2] === undefined) {
         printUsageAndExit(CHANNELS_COMMAND_HELP.create);
       }
       if (looksLikePositionalChannelKind(args, 2)) {
@@ -482,7 +474,7 @@ async function main() {
     printHelpAndExit(CHANNELS_HELP);
   }
 
-  if (isChannelsHelpRequest(args)) {
+  if (isSubcommandHelpRequest(args)) {
     printHelpAndExit(getChannelsHelp(command));
   }
 
@@ -528,7 +520,7 @@ async function main() {
       case "create": {
         const groupId = args[1];
         const title = args[2];
-        if (!groupId || !title) {
+        if (!groupId || title === undefined) {
           console.error(CHANNELS_COMMAND_HELP.create);
           process.exit(1);
         }
@@ -537,8 +529,8 @@ async function main() {
           console.error(CHANNELS_COMMAND_HELP.create);
           process.exit(1);
         }
-        const kind = (getOption(args, "kind") as "chat" | "diary" | "heap") || "chat";
-        const description = getOption(args, "description") || "";
+        const kind = (getOption(args, "kind", 3) as "chat" | "diary" | "heap") || "chat";
+        const description = getOption(args, "description", 3) || "";
         await createChannelInGroup(groupId, title, kind, description);
         break;
       }

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -30,7 +30,15 @@ import {
 } from "@tloncorp/api";
 import type { Channel as ApiChannel, Group as ApiGroup } from "@tloncorp/api";
 import { ensureClient, getCurrentShip } from "./api-client";
-import { getOption, looksLikePositionalChannelKind, wantsHelp } from "./cli-utils";
+import {
+  getOption,
+  isHelpArg,
+  looksLikePositionalChannelKind,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
 
 function generateChannelSlug(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz";
@@ -42,7 +50,7 @@ function generateChannelSlug(): string {
   return slug;
 }
 
-const CHANNELS_HELP = `Usage: channels.ts <command>
+const CHANNELS_HELP = `Usage: tlon channels <command>
 
 Commands:
   dms
@@ -60,27 +68,87 @@ Commands:
   del-readers <group-flag> <nest> <role1> [role2...]
 
 Examples:
-  channels.ts create ~host/group-slug "Projects" --kind chat
-  channels.ts rename chat/~host/project-updates "Team Updates"`;
+  tlon channels create ~host/group-slug "Projects" --kind chat
+  tlon channels rename chat/~host/project-updates "Team Updates"`;
 
 const CHANNELS_COMMAND_HELP: Record<string, string> = {
-  dms: `Usage: channels.ts dms`,
-  "group-dms": `Usage: channels.ts group-dms`,
-  groups: `Usage: channels.ts groups`,
-  all: `Usage: channels.ts all`,
-  info: `Usage: channels.ts info <nest>\nExample: channels.ts info chat/~host/slug`,
-  create: `Usage: channels.ts create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]\nExample: channels.ts create ~host/group-slug "Projects" --kind chat`,
-  update: `Usage: channels.ts update <nest> --title "..." [--description "..."]\nExample: channels.ts update chat/~host/slug --title "New Title"`,
-  rename: `Usage: channels.ts rename <nest> "New Title"\nExample: channels.ts rename chat/~host/slug "Project Updates"`,
-  delete: `Usage: channels.ts delete <nest>\nExample: channels.ts delete chat/~host/slug`,
-  "add-writers": `Usage: channels.ts add-writers <nest> <role1> [role2...]\nExample: channels.ts add-writers chat/~host/slug admin`,
-  "del-writers": `Usage: channels.ts del-writers <nest> <role1> [role2...]\nExample: channels.ts del-writers chat/~host/slug member`,
-  "add-readers": `Usage: channels.ts add-readers <group-flag> <nest> <role1> [role2...]\nExample: channels.ts add-readers ~host/group-slug chat/~host/slug admin`,
-  "del-readers": `Usage: channels.ts del-readers <group-flag> <nest> <role1> [role2...]\nExample: channels.ts del-readers ~host/group-slug chat/~host/slug admin`,
+  dms: `Usage: tlon channels dms`,
+  "group-dms": `Usage: tlon channels group-dms`,
+  groups: `Usage: tlon channels groups`,
+  all: `Usage: tlon channels all`,
+  info: `Usage: tlon channels info <nest>\nExample: tlon channels info chat/~host/slug`,
+  create: `Usage: tlon channels create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]\nExample: tlon channels create ~host/group-slug "Projects" --kind chat`,
+  update: `Usage: tlon channels update <nest> --title "..." [--description "..."]\nExample: tlon channels update chat/~host/slug --title "New Title"`,
+  rename: `Usage: tlon channels rename <nest> "New Title"\nExample: tlon channels rename chat/~host/slug "Project Updates"`,
+  delete: `Usage: tlon channels delete <nest>\nExample: tlon channels delete chat/~host/slug`,
+  "add-writers": `Usage: tlon channels add-writers <nest> <role1> [role2...]\nExample: tlon channels add-writers chat/~host/slug admin`,
+  "del-writers": `Usage: tlon channels del-writers <nest> <role1> [role2...]\nExample: tlon channels del-writers chat/~host/slug member`,
+  "add-readers": `Usage: tlon channels add-readers <group-flag> <nest> <role1> [role2...]\nExample: tlon channels add-readers ~host/group-slug chat/~host/slug admin`,
+  "del-readers": `Usage: tlon channels del-readers <group-flag> <nest> <role1> [role2...]\nExample: tlon channels del-readers ~host/group-slug chat/~host/slug admin`,
 };
 
-function printChannelsHelp(command?: string) {
-  console.log(command ? CHANNELS_COMMAND_HELP[command] ?? CHANNELS_HELP : CHANNELS_HELP);
+function getChannelsHelp(command?: string) {
+  return command ? CHANNELS_COMMAND_HELP[command] ?? CHANNELS_HELP : CHANNELS_HELP;
+}
+
+function validateChannelsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !CHANNELS_COMMAND_HELP[command]) {
+    printUsageAndExit(CHANNELS_HELP);
+  }
+
+  switch (command) {
+    case "dms":
+    case "group-dms":
+    case "groups":
+    case "all":
+      return;
+    case "info":
+    case "delete": {
+      if (!args[1]) printUsageAndExit(CHANNELS_COMMAND_HELP[command]);
+      return;
+    }
+    case "create": {
+      if (!args[1] || !args[2] || args[2].startsWith("--")) {
+        printUsageAndExit(CHANNELS_COMMAND_HELP.create);
+      }
+      if (looksLikePositionalChannelKind(args, 2)) {
+        printUsageAndExit(
+          `Error: channel kind must be passed with --kind, not as a positional argument.\n${CHANNELS_COMMAND_HELP.create}`
+        );
+      }
+      return;
+    }
+    case "update": {
+      if (!args[1]) printUsageAndExit(CHANNELS_COMMAND_HELP.update);
+      if (!getOption(args, "title") && !getOption(args, "description")) {
+        printUsageAndExit(
+          `Error: At least one of --title or --description is required\n${CHANNELS_COMMAND_HELP.update}`
+        );
+      }
+      return;
+    }
+    case "rename": {
+      if (!args[1] || !args[2] || args[2].startsWith("--")) {
+        printUsageAndExit(CHANNELS_COMMAND_HELP.rename);
+      }
+      return;
+    }
+    case "add-writers":
+    case "del-writers": {
+      if (!args[1] || args.slice(2).length === 0) {
+        printUsageAndExit(CHANNELS_COMMAND_HELP[command]);
+      }
+      return;
+    }
+    case "add-readers":
+    case "del-readers": {
+      if (!args[1] || !args[2] || args.slice(3).length === 0) {
+        printUsageAndExit(CHANNELS_COMMAND_HELP[command]);
+      }
+      return;
+    }
+  }
 }
 
 // Get DMs
@@ -395,15 +463,15 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
-  if (!command || command === "--help" || command === "-h") {
-    printChannelsHelp();
-    process.exit(0);
+  if (isHelpArg(command)) {
+    printHelpAndExit(CHANNELS_HELP);
   }
 
   if (wantsHelp(args.slice(1))) {
-    printChannelsHelp(command);
-    process.exit(0);
+    printHelpAndExit(getChannelsHelp(command));
   }
+
+  validateChannelsArgs(args);
 
   try {
     await ensureClient(["channels"]);
@@ -548,13 +616,11 @@ async function main() {
       }
 
       default:
-        printChannelsHelp();
-        process.exit(1);
+        printUsageAndExit(CHANNELS_HELP);
     }
     process.exit(0);
-  } catch (error: any) {
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
+  } catch (error) {
+    printErrorAndExit(error);
   }
 }
 

--- a/scripts/cli-test-matrix.ts
+++ b/scripts/cli-test-matrix.ts
@@ -178,6 +178,11 @@ export const SPECIAL_INPUT_CASES: CliCase[] = [
     "Usage: tlon posts edit"
   ),
   usageErrorCase(
+    "groups update missing update flag",
+    ["groups", "update", "~host/group-slug"],
+    "At least one of --title, --description, --image, or --cover is required"
+  ),
+  usageErrorCase(
     "hooks init invalid type",
     ["hooks", "init", "my-hook", "--type", "definitely-not-a-type"],
     "Invalid --type: definitely-not-a-type"

--- a/scripts/cli-test-matrix.ts
+++ b/scripts/cli-test-matrix.ts
@@ -117,6 +117,17 @@ function usageErrorCase(name: string, args: string[], usage = "Usage:"): CliCase
   };
 }
 
+function authRequiredCase(name: string, args: string[]): CliCase {
+  return {
+    name,
+    args,
+    expectedExitCode: 1,
+    stdoutExcludes: ["Usage:"],
+    stderrIncludes: ["Missing Urbit config"],
+    stderrExcludes: ["Usage:"],
+  };
+}
+
 export const TOP_LEVEL_HELP_CASE = helpCase("top-level --help", ["--help"], "tlon");
 
 export const UNKNOWN_TOP_LEVEL_CASE: CliCase = {
@@ -187,6 +198,16 @@ export const SPECIAL_INPUT_CASES: CliCase[] = [
     ["hooks", "init", "my-hook", "--type", "definitely-not-a-type"],
     "Invalid --type: definitely-not-a-type"
   ),
+  usageErrorCase(
+    "hooks init missing type value",
+    ["hooks", "init", "my-hook", "--type"],
+    "Usage: tlon hooks init"
+  ),
+  usageErrorCase(
+    "hooks init type followed by known option",
+    ["hooks", "init", "my-hook", "--type", "--out", "hook.hoon"],
+    "Usage: tlon hooks init"
+  ),
   {
     ...usageErrorCase(
       "upload unknown option",
@@ -230,6 +251,159 @@ export const NESTED_HELP_CASES: CliCase[] = [
   ),
 ];
 
+export const LITERAL_OPTION_LIKE_VALUE_CASES: CliCase[] = [
+  authRequiredCase("dms send message option-like value reaches auth", [
+    "dms",
+    "send",
+    "0v123",
+    "use",
+    "--help",
+  ]),
+  authRequiredCase("dms reply message option-like value reaches auth", [
+    "dms",
+    "reply",
+    "0v123",
+    "~zod/170.141",
+    "use",
+    "--help",
+  ]),
+  authRequiredCase("posts edit message option-like value reaches auth", [
+    "posts",
+    "edit",
+    "chat/~host/channel",
+    "170.141",
+    "use",
+    "--help",
+  ]),
+  authRequiredCase("messages search query option-like value reaches auth", [
+    "messages",
+    "search",
+    "--channel",
+    "--channel",
+    "chat/~host/channel",
+  ]),
+  authRequiredCase("contacts update-profile value option-like value reaches auth", [
+    "contacts",
+    "update-profile",
+    "--status",
+    "--help",
+  ]),
+  authRequiredCase("contacts update value option-like value reaches auth", [
+    "contacts",
+    "update",
+    "~zod",
+    "--nickname",
+    "-h",
+  ]),
+  authRequiredCase("channels create title option-like value reaches auth", [
+    "channels",
+    "create",
+    "~host/group",
+    "--roadmap",
+  ]),
+  authRequiredCase("channels create exact flag-name title reaches auth", [
+    "channels",
+    "create",
+    "~host/group",
+    "--kind",
+  ]),
+  authRequiredCase("channels rename title option-like value reaches auth", [
+    "channels",
+    "rename",
+    "chat/~host/channel",
+    "--roadmap",
+  ]),
+  authRequiredCase("channels update title option-like value reaches auth", [
+    "channels",
+    "update",
+    "chat/~host/channel",
+    "--title",
+    "--help",
+  ]),
+  authRequiredCase("groups create title option-like value reaches auth", [
+    "groups",
+    "create",
+    "--roadmap",
+  ]),
+  authRequiredCase("groups create exact flag-name title reaches auth", [
+    "groups",
+    "create",
+    "--description",
+  ]),
+  authRequiredCase("groups create-owned title option-like value reaches auth", [
+    "groups",
+    "create-owned",
+    "--roadmap",
+    "--owner",
+    "~zod",
+  ]),
+  authRequiredCase("groups create-owned exact flag-name title reaches auth", [
+    "groups",
+    "create-owned",
+    "--owner",
+    "--owner",
+    "~zod",
+  ]),
+  authRequiredCase("groups update title option-like value reaches auth", [
+    "groups",
+    "update",
+    "~host/group",
+    "--title",
+    "--help",
+  ]),
+  authRequiredCase("groups add-channel title option-like value reaches auth", [
+    "groups",
+    "add-channel",
+    "~host/group",
+    "--announcements",
+  ]),
+  authRequiredCase("groups add-channel exact flag-name title reaches auth", [
+    "groups",
+    "add-channel",
+    "~host/group",
+    "--kind",
+  ]),
+  authRequiredCase("hooks edit name option-like value reaches auth", [
+    "hooks",
+    "edit",
+    "0v1a",
+    "--name",
+    "--help",
+  ]),
+  authRequiredCase("notebook title option-like value reaches auth", [
+    "notebook",
+    "diary/~host/notes",
+    "--help",
+  ]),
+  authRequiredCase("contacts update-profile empty value reaches auth", [
+    "contacts",
+    "update-profile",
+    "--status",
+    "",
+  ]),
+  authRequiredCase("contacts update empty value reaches auth", [
+    "contacts",
+    "update",
+    "~zod",
+    "--nickname",
+    "",
+  ]),
+  authRequiredCase("channels update empty value reaches auth", [
+    "channels",
+    "update",
+    "chat/~host/channel",
+    "--description",
+    "",
+  ]),
+  authRequiredCase("groups update empty value reaches auth", [
+    "groups",
+    "update",
+    "~host/group",
+    "--description",
+    "",
+  ]),
+];
+
 export const CLI_MATRIX_CASES: CliCase[] = [
   TOP_LEVEL_HELP_CASE,
   UNKNOWN_TOP_LEVEL_CASE,
@@ -239,6 +413,7 @@ export const CLI_MATRIX_CASES: CliCase[] = [
   ...MISSING_REQUIRED_CASES,
   ...SPECIAL_INPUT_CASES,
   ...NESTED_HELP_CASES,
+  ...LITERAL_OPTION_LIKE_VALUE_CASES,
 ];
 
 export function normalizeCliOutput(text: string): string {

--- a/scripts/cli-test-matrix.ts
+++ b/scripts/cli-test-matrix.ts
@@ -1,0 +1,201 @@
+export const COMMAND_FAMILIES = [
+  "activity",
+  "channels",
+  "contacts",
+  "dms",
+  "expose",
+  "groups",
+  "hooks",
+  "messages",
+  "notebook",
+  "posts",
+  "settings",
+  "upload",
+] as const;
+
+export const SUBCOMMAND_FAMILIES = COMMAND_FAMILIES.filter(
+  (family) => family !== "notebook" && family !== "upload"
+);
+
+export type CliCase = {
+  name: string;
+  args: string[];
+  expectedExitCode: number;
+  stdout?: string;
+  stderr?: string;
+  stdoutIncludes?: string[];
+  stderrIncludes?: string[];
+  stdoutExcludes?: string[];
+  stderrExcludes?: string[];
+};
+
+const SCRIPT_ERA_PATTERNS = [
+  "npx ts-node",
+  "activity.ts",
+  "channels.ts",
+  "contacts.ts",
+  "dms.ts",
+  "expose.ts",
+  "groups.ts",
+  "hooks.ts",
+  "main.ts",
+  "messages.ts",
+  "notebook-post.ts",
+  "posts.ts",
+  "settings.ts",
+  "upload.ts",
+];
+
+const STACK_PATTERNS = [
+  "\n    at ",
+  "\n  at ",
+  "api-client.ts:",
+  "notebook-post.ts:",
+  "dist/tlon-run:",
+  "error: Uncaught",
+];
+
+const AUTH_CONFIG_PATTERNS = [
+  "Missing Urbit config",
+  "Multiple cached ships",
+  "Ship config not found",
+  "Invalid config:",
+  "Failed to parse config",
+  "OpenClaw",
+  "TLON_CONFIG_FILE",
+  "TLON_CACHE_DIR",
+  "Using cached credentials",
+  "Credentials cached",
+];
+
+function helpCase(name: string, args: string[], usage: string): CliCase {
+  return {
+    name,
+    args,
+    expectedExitCode: 0,
+    stderr: "",
+    stdoutIncludes: ["Usage:", usage],
+    stdoutExcludes: SCRIPT_ERA_PATTERNS,
+  };
+}
+
+function usageErrorCase(name: string, args: string[], usage = "Usage:"): CliCase {
+  return {
+    name,
+    args,
+    expectedExitCode: 1,
+    stdout: "",
+    stderrIncludes: [usage],
+    stderrExcludes: [
+      ...SCRIPT_ERA_PATTERNS,
+      ...STACK_PATTERNS,
+      ...AUTH_CONFIG_PATTERNS,
+    ],
+  };
+}
+
+export const TOP_LEVEL_HELP_CASE = helpCase("top-level --help", ["--help"], "tlon");
+
+export const UNKNOWN_TOP_LEVEL_CASE: CliCase = {
+  name: "unknown top-level command",
+  args: ["definitely-not-a-command"],
+  expectedExitCode: 1,
+  stdout: "",
+  stderrIncludes: [
+    "Unknown command: definitely-not-a-command",
+    'Run "tlon --help" for usage information.',
+  ],
+  stderrExcludes: [...STACK_PATTERNS, ...AUTH_CONFIG_PATTERNS],
+};
+
+export const FAMILY_HELP_CASES: CliCase[] = COMMAND_FAMILIES.flatMap((family) => [
+  helpCase(`${family} --help`, [family, "--help"], `tlon ${family}`),
+  helpCase(`${family} -h`, [family, "-h"], `tlon ${family}`),
+]);
+
+export const FAMILY_BARE_CASES: CliCase[] = COMMAND_FAMILIES.map((family) =>
+  usageErrorCase(`${family} bare invocation`, [family], `Usage: tlon ${family}`)
+);
+
+export const INVALID_SUBCOMMAND_CASES: CliCase[] = SUBCOMMAND_FAMILIES.map((family) =>
+  usageErrorCase(`${family} invalid subcommand`, [
+    family,
+    "definitely-not-a-subcommand",
+  ])
+);
+
+export const MISSING_REQUIRED_CASES: CliCase[] = [
+  usageErrorCase("channels info missing nest", ["channels", "info"], "Usage: tlon channels info"),
+  usageErrorCase("contacts get missing ship", ["contacts", "get"], "Usage: tlon contacts get"),
+  usageErrorCase("dms send missing args", ["dms", "send"], "Usage: tlon dms send"),
+  usageErrorCase("expose show missing cite", ["expose", "show"], "Usage: tlon expose show"),
+  usageErrorCase("groups info missing id", ["groups", "info"], "Usage: tlon groups info"),
+  usageErrorCase("hooks init missing name", ["hooks", "init"], "Usage: tlon hooks init"),
+  usageErrorCase("messages dm missing ship", ["messages", "dm"], "Usage: tlon messages dm"),
+  usageErrorCase("notebook missing args", ["notebook"], "Usage: tlon notebook"),
+  usageErrorCase("posts react missing args", ["posts", "react"], "Usage: tlon posts react"),
+  usageErrorCase("settings set missing args", ["settings", "set"], "Usage: tlon settings set"),
+  usageErrorCase("upload missing input", ["upload"], "Usage: tlon upload"),
+];
+
+export const SPECIAL_INPUT_CASES: CliCase[] = [
+  {
+    ...usageErrorCase(
+      "upload unknown option",
+      ["upload", "--definitely-not-an-option"],
+      "Unknown option: --definitely-not-an-option"
+    ),
+    stderrIncludes: [
+      "Error: Unknown option: --definitely-not-an-option",
+      "Usage: tlon upload",
+    ],
+  },
+  {
+    name: "notebook unknown option",
+    args: [
+      "notebook",
+      "diary/~host/notes",
+      "Title",
+      "--definitely-not-an-option",
+    ],
+    expectedExitCode: 1,
+    stdout: "",
+    stderrIncludes: ["Error: Unknown option: --definitely-not-an-option"],
+    stderrExcludes: [
+      ...SCRIPT_ERA_PATTERNS,
+      ...STACK_PATTERNS,
+      ...AUTH_CONFIG_PATTERNS,
+    ],
+  },
+];
+
+export const NESTED_HELP_CASES: CliCase[] = [
+  helpCase(
+    "channels info --help",
+    ["channels", "info", "--help"],
+    "Usage: tlon channels info"
+  ),
+  helpCase(
+    "groups info --help",
+    ["groups", "info", "--help"],
+    "Usage: tlon groups info"
+  ),
+];
+
+export const CLI_MATRIX_CASES: CliCase[] = [
+  TOP_LEVEL_HELP_CASE,
+  UNKNOWN_TOP_LEVEL_CASE,
+  ...FAMILY_HELP_CASES,
+  ...FAMILY_BARE_CASES,
+  ...INVALID_SUBCOMMAND_CASES,
+  ...MISSING_REQUIRED_CASES,
+  ...SPECIAL_INPUT_CASES,
+  ...NESTED_HELP_CASES,
+];
+
+export function normalizeCliOutput(text: string): string {
+  return text
+    .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+}

--- a/scripts/cli-test-matrix.ts
+++ b/scripts/cli-test-matrix.ts
@@ -31,19 +31,42 @@ export type CliCase = {
 
 const SCRIPT_ERA_PATTERNS = [
   "npx ts-node",
-  "activity.ts",
-  "channels.ts",
-  "contacts.ts",
-  "dms.ts",
-  "expose.ts",
-  "groups.ts",
-  "hooks.ts",
-  "main.ts",
-  "messages.ts",
-  "notebook-post.ts",
-  "posts.ts",
-  "settings.ts",
-  "upload.ts",
+  "Usage: activity.ts",
+  "Usage: channels.ts",
+  "Usage: contacts.ts",
+  "Usage: dms.ts",
+  "Usage: expose.ts",
+  "Usage: groups.ts",
+  "Usage: hooks.ts",
+  "Usage: messages.ts",
+  "Usage: notebook-post.ts",
+  "Usage: posts.ts",
+  "Usage: settings.ts",
+  "Usage: upload.ts",
+  "Example: activity.ts",
+  "Example: channels.ts",
+  "Example: contacts.ts",
+  "Example: dms.ts",
+  "Example: expose.ts",
+  "Example: groups.ts",
+  "Example: hooks.ts",
+  "Example: messages.ts",
+  "Example: notebook-post.ts",
+  "Example: posts.ts",
+  "Example: settings.ts",
+  "Example: upload.ts",
+  "scripts/activity.ts",
+  "scripts/channels.ts",
+  "scripts/contacts.ts",
+  "scripts/dms.ts",
+  "scripts/expose.ts",
+  "scripts/groups.ts",
+  "scripts/hooks.ts",
+  "scripts/messages.ts",
+  "scripts/notebook-post.ts",
+  "scripts/posts.ts",
+  "scripts/settings.ts",
+  "scripts/upload.ts",
 ];
 
 const STACK_PATTERNS = [
@@ -139,6 +162,26 @@ export const MISSING_REQUIRED_CASES: CliCase[] = [
 ];
 
 export const SPECIAL_INPUT_CASES: CliCase[] = [
+  usageErrorCase(
+    "contacts update-profile missing flag value",
+    ["contacts", "update-profile", "--nickname"],
+    "Usage: tlon contacts update-profile"
+  ),
+  usageErrorCase(
+    "messages search missing query",
+    ["messages", "search", "--channel", "chat/~host/slug"],
+    "Usage: tlon messages search"
+  ),
+  usageErrorCase(
+    "posts edit missing message",
+    ["posts", "edit", "chat/~host/channel", "170.141"],
+    "Usage: tlon posts edit"
+  ),
+  usageErrorCase(
+    "hooks init invalid type",
+    ["hooks", "init", "my-hook", "--type", "definitely-not-a-type"],
+    "Invalid --type: definitely-not-a-type"
+  ),
   {
     ...usageErrorCase(
       "upload unknown option",

--- a/scripts/cli-utils.test.ts
+++ b/scripts/cli-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   getOption,
   getRequiredOptionValue,
+  hasOptionValue,
   looksLikePositionalChannelKind,
   wantsHelp,
 } from "./cli-utils";
@@ -54,6 +55,20 @@ describe("cli-utils", () => {
       expect(() => getRequiredOptionValue(["--content", "--markdown", "post.md"], 0)).toThrow(
         "--content requires a value"
       );
+    });
+  });
+
+  describe("hasOptionValue", () => {
+    it("allows values that start with dashes when they are not known options", () => {
+      const args = ["update-profile", "--bio", "--starts-with-dashes"];
+
+      expect(hasOptionValue(args, "bio", ["nickname", "bio"])).toBe(true);
+    });
+
+    it("treats a following known option as a missing value", () => {
+      const args = ["update-profile", "--bio", "--nickname", "Pat"];
+
+      expect(hasOptionValue(args, "bio", ["nickname", "bio"])).toBe(false);
     });
   });
 });

--- a/scripts/cli-utils.test.ts
+++ b/scripts/cli-utils.test.ts
@@ -34,6 +34,10 @@ describe("cli-utils", () => {
       expect(getOption(args, "kind")).toBe("chat");
     });
 
+    it("preserves empty option values", () => {
+      expect(getOption(["update", "--description", ""], "description")).toBe("");
+    });
+
     it("does not flag ordinary titles", () => {
       const args = ["add-channel", "~zod/test", "Projects"];
       expect(looksLikePositionalChannelKind(args, 2)).toBe(false);
@@ -69,6 +73,12 @@ describe("cli-utils", () => {
       const args = ["update-profile", "--bio", "--nickname", "Pat"];
 
       expect(hasOptionValue(args, "bio", ["nickname", "bio"])).toBe(false);
+    });
+
+    it("treats an empty string as an explicit option value", () => {
+      const args = ["update-profile", "--status", ""];
+
+      expect(hasOptionValue(args, "status", ["status"])).toBe(true);
     });
   });
 });

--- a/scripts/cli-utils.test.ts
+++ b/scripts/cli-utils.test.ts
@@ -3,6 +3,8 @@ import {
   getOption,
   getRequiredOptionValue,
   hasOptionValue,
+  isCommandHelpRequest,
+  isSubcommandHelpRequest,
   looksLikePositionalChannelKind,
   wantsHelp,
 } from "./cli-utils";
@@ -36,6 +38,12 @@ describe("cli-utils", () => {
 
     it("preserves empty option values", () => {
       expect(getOption(["update", "--description", ""], "description")).toBe("");
+    });
+
+    it("can ignore positional values before options", () => {
+      const args = ["create-owned", "--owner", "--owner", "~zod"];
+
+      expect(getOption(args, "owner", 2)).toBe("~zod");
     });
 
     it("does not flag ordinary titles", () => {
@@ -79,6 +87,20 @@ describe("cli-utils", () => {
       const args = ["update-profile", "--status", ""];
 
       expect(hasOptionValue(args, "status", ["status"])).toBe(true);
+    });
+  });
+
+  describe("explicit help slots", () => {
+    it("detects family subcommand help only in the second slot", () => {
+      expect(isSubcommandHelpRequest(["info", "--help"])).toBe(true);
+      expect(isSubcommandHelpRequest(["info", "-h"])).toBe(true);
+      expect(isSubcommandHelpRequest(["info", "~zod/test", "--help"])).toBe(false);
+    });
+
+    it("detects command-only help only in the first slot", () => {
+      expect(isCommandHelpRequest(["--help"])).toBe(true);
+      expect(isCommandHelpRequest(["-h"])).toBe(true);
+      expect(isCommandHelpRequest(["diary/~zod/test", "--help"])).toBe(false);
     });
   });
 });

--- a/scripts/cli-utils.ts
+++ b/scripts/cli-utils.ts
@@ -10,7 +10,7 @@
  */
 export function getOption(args: string[], name: string): string | undefined {
   const idx = args.indexOf(`--${name}`);
-  if (idx !== -1 && args[idx + 1]) {
+  if (idx !== -1 && args[idx + 1] !== undefined) {
     return args[idx + 1];
   }
   return undefined;
@@ -23,7 +23,7 @@ export function hasOptionValue(
 ): boolean {
   const idx = args.indexOf(`--${name}`);
   const value = idx !== -1 ? args[idx + 1] : undefined;
-  if (!value) {
+  if (value === undefined) {
     return false;
   }
 

--- a/scripts/cli-utils.ts
+++ b/scripts/cli-utils.ts
@@ -16,10 +16,18 @@ export function getOption(args: string[], name: string): string | undefined {
   return undefined;
 }
 
-export function hasOptionValue(args: string[], name: string): boolean {
+export function hasOptionValue(
+  args: string[],
+  name: string,
+  knownOptionNames: readonly string[] = []
+): boolean {
   const idx = args.indexOf(`--${name}`);
   const value = idx !== -1 ? args[idx + 1] : undefined;
-  return !!value && !value.startsWith("--");
+  if (!value) {
+    return false;
+  }
+
+  return !knownOptionNames.some((optionName) => value === `--${optionName}`);
 }
 
 /**

--- a/scripts/cli-utils.ts
+++ b/scripts/cli-utils.ts
@@ -44,6 +44,29 @@ export function wantsHelp(args: string[]): boolean {
   return args.includes("--help") || args.includes("-h");
 }
 
+export function isHelpArg(arg: string | undefined): boolean {
+  return arg === "--help" || arg === "-h";
+}
+
+export function printHelpAndExit(help: string): never {
+  console.log(help);
+  process.exit(0);
+}
+
+export function printUsageAndExit(help: string): never {
+  console.error(help);
+  process.exit(1);
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function printErrorAndExit(error: unknown): never {
+  console.error(`Error: ${errorMessage(error)}`);
+  process.exit(1);
+}
+
 export const CHANNEL_KINDS = ["chat", "diary", "heap"] as const;
 
 /**

--- a/scripts/cli-utils.ts
+++ b/scripts/cli-utils.ts
@@ -16,6 +16,12 @@ export function getOption(args: string[], name: string): string | undefined {
   return undefined;
 }
 
+export function hasOptionValue(args: string[], name: string): boolean {
+  const idx = args.indexOf(`--${name}`);
+  const value = idx !== -1 ? args[idx + 1] : undefined;
+  return !!value && !value.startsWith("--");
+}
+
 /**
  * Check if a flag is present in args
  * @param args Array of arguments

--- a/scripts/cli-utils.ts
+++ b/scripts/cli-utils.ts
@@ -6,10 +6,15 @@
  * Get an option value from command line args
  * @param args Array of arguments
  * @param name Option name (without --)
+ * @param startIndex Index to begin searching from
  * @returns The option value or undefined
  */
-export function getOption(args: string[], name: string): string | undefined {
-  const idx = args.indexOf(`--${name}`);
+export function getOption(
+  args: string[],
+  name: string,
+  startIndex = 0
+): string | undefined {
+  const idx = args.indexOf(`--${name}`, startIndex);
   if (idx !== -1 && args[idx + 1] !== undefined) {
     return args[idx + 1];
   }
@@ -60,6 +65,14 @@ export function wantsHelp(args: string[]): boolean {
 
 export function isHelpArg(arg: string | undefined): boolean {
   return arg === "--help" || arg === "-h";
+}
+
+export function isSubcommandHelpRequest(args: string[]): boolean {
+  return args.length === 2 && isHelpArg(args[1]);
+}
+
+export function isCommandHelpRequest(args: string[]): boolean {
+  return args.length === 1 && isHelpArg(args[0]);
 }
 
 export function printHelpAndExit(help: string): never {

--- a/scripts/contacts.ts
+++ b/scripts/contacts.ts
@@ -91,7 +91,11 @@ function validateContactsArgs(args: string[]): void {
       return;
     }
     case "update-profile": {
-      if (!PROFILE_UPDATE_FLAGS.some((flag) => hasOptionValue(args, flag))) {
+      if (
+        !PROFILE_UPDATE_FLAGS.some((flag) =>
+          hasOptionValue(args, flag, PROFILE_UPDATE_FLAGS)
+        )
+      ) {
         printUsageAndExit(CONTACTS_COMMAND_HELP["update-profile"]);
       }
       return;

--- a/scripts/contacts.ts
+++ b/scripts/contacts.ts
@@ -18,6 +18,7 @@ import {
 import type { Contact } from "@tloncorp/api";
 import { ensureClient, normalizeShip } from "./api-client";
 import {
+  hasOptionValue,
   isHelpArg,
   printErrorAndExit,
   printHelpAndExit,
@@ -32,6 +33,8 @@ interface ContactEditField {
   avatar?: string;
   cover?: string;
 }
+
+const PROFILE_UPDATE_FLAGS = ["nickname", "bio", "status", "avatar", "cover"] as const;
 
 const CONTACTS_HELP = `Usage: tlon contacts <command>
 
@@ -88,11 +91,7 @@ function validateContactsArgs(args: string[]): void {
       return;
     }
     case "update-profile": {
-      if (
-        !["--nickname", "--bio", "--status", "--avatar", "--cover"].some((flag) =>
-          args.includes(flag)
-        )
-      ) {
+      if (!PROFILE_UPDATE_FLAGS.some((flag) => hasOptionValue(args, flag))) {
         printUsageAndExit(CONTACTS_COMMAND_HELP["update-profile"]);
       }
       return;

--- a/scripts/contacts.ts
+++ b/scripts/contacts.ts
@@ -20,6 +20,7 @@ import { ensureClient, normalizeShip } from "./api-client";
 import {
   hasOptionValue,
   isHelpArg,
+  isSubcommandHelpRequest,
   printErrorAndExit,
   printHelpAndExit,
   printUsageAndExit,
@@ -68,10 +69,6 @@ const CONTACTS_COMMAND_HELP: Record<string, string> = {
 
 function getContactsHelp(command?: string): string {
   return command ? CONTACTS_COMMAND_HELP[command] ?? CONTACTS_HELP : CONTACTS_HELP;
-}
-
-function isContactsHelpRequest(args: string[]): boolean {
-  return args.length === 2 && isHelpArg(args[1]);
 }
 
 function validateContactsArgs(args: string[]): void {
@@ -256,7 +253,7 @@ async function main() {
       printHelpAndExit(CONTACTS_HELP);
     }
 
-    if (isContactsHelpRequest(args)) {
+    if (isSubcommandHelpRequest(args)) {
       printHelpAndExit(getContactsHelp(command));
     }
 

--- a/scripts/contacts.ts
+++ b/scripts/contacts.ts
@@ -17,6 +17,13 @@ import {
 } from "@tloncorp/api";
 import type { Contact } from "@tloncorp/api";
 import { ensureClient, normalizeShip } from "./api-client";
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
 
 interface ContactEditField {
   nickname?: string;
@@ -24,6 +31,73 @@ interface ContactEditField {
   status?: string;
   avatar?: string;
   cover?: string;
+}
+
+const CONTACTS_HELP = `Usage: tlon contacts <command>
+
+Commands:
+  list                     List all contacts
+  self                     Show your profile
+  get ~ship                Get a contact's profile
+  sync ~ship [~ship2 ...]  Sync profiles
+  add ~ship                Add a contact
+  remove ~ship             Remove a contact
+  update ~ship --nickname <name> --avatar <url>
+                           Update a contact's metadata
+  update-profile [options] Update your profile
+
+Examples:
+  tlon contacts list
+  tlon contacts get ~sampel-palnet
+  tlon contacts update-profile --nickname "New Name"`;
+
+const CONTACTS_COMMAND_HELP: Record<string, string> = {
+  list: "Usage: tlon contacts list",
+  self: "Usage: tlon contacts self",
+  get: "Usage: tlon contacts get ~ship",
+  sync: "Usage: tlon contacts sync ~ship [~ship2 ...]",
+  add: "Usage: tlon contacts add ~ship",
+  remove: "Usage: tlon contacts remove ~ship",
+  del: "Usage: tlon contacts remove ~ship",
+  update: "Usage: tlon contacts update ~ship [--nickname <name>] [--avatar <url>]",
+  "update-profile":
+    "Usage: tlon contacts update-profile [--nickname <name>] [--bio <text>] [--status <text>] [--avatar <url>] [--cover <url>]",
+};
+
+function getContactsHelp(command?: string): string {
+  return command ? CONTACTS_COMMAND_HELP[command] ?? CONTACTS_HELP : CONTACTS_HELP;
+}
+
+function validateContactsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !CONTACTS_COMMAND_HELP[command]) {
+    printUsageAndExit(CONTACTS_HELP);
+  }
+
+  switch (command) {
+    case "list":
+    case "self":
+      return;
+    case "get":
+    case "sync":
+    case "add":
+    case "remove":
+    case "del":
+    case "update": {
+      if (!args[1]) printUsageAndExit(CONTACTS_COMMAND_HELP[command]);
+      return;
+    }
+    case "update-profile": {
+      if (
+        !["--nickname", "--bio", "--status", "--avatar", "--cover"].some((flag) =>
+          args.includes(flag)
+        )
+      ) {
+        printUsageAndExit(CONTACTS_COMMAND_HELP["update-profile"]);
+      }
+      return;
+    }
+  }
 }
 
 // Helper to extract profile values
@@ -172,6 +246,16 @@ async function main() {
   const command = args[0];
 
   try {
+    if (isHelpArg(command)) {
+      printHelpAndExit(CONTACTS_HELP);
+    }
+
+    if (wantsHelp(args.slice(1))) {
+      printHelpAndExit(getContactsHelp(command));
+    }
+
+    validateContactsArgs(args);
+
     await ensureClient();
     let result: any;
 
@@ -186,24 +270,21 @@ async function main() {
 
       case "get":
         if (!args[1]) {
-          console.error("Usage: contacts.ts get ~ship");
-          process.exit(1);
+          printUsageAndExit(CONTACTS_COMMAND_HELP.get);
         }
         result = await getContact(args[1]);
         break;
 
       case "sync":
         if (!args[1]) {
-          console.error("Usage: contacts.ts sync ~ship [~ship2 ...]");
-          process.exit(1);
+          printUsageAndExit(CONTACTS_COMMAND_HELP.sync);
         }
         result = await syncProfiles(args.slice(1));
         break;
 
       case "add":
         if (!args[1]) {
-          console.error("Usage: contacts.ts add ~ship");
-          process.exit(1);
+          printUsageAndExit(CONTACTS_COMMAND_HELP.add);
         }
         result = await addContact(args[1]);
         break;
@@ -211,8 +292,7 @@ async function main() {
       case "remove":
       case "del":
         if (!args[1]) {
-          console.error("Usage: contacts.ts remove ~ship");
-          process.exit(1);
+          printUsageAndExit(CONTACTS_COMMAND_HELP.remove);
         }
         result = await removeContact(args[1]);
         break;
@@ -220,8 +300,7 @@ async function main() {
       case "update": {
         const ship = args[1];
         if (!ship) {
-          console.error("Usage: contacts.ts update ~ship [--nickname <name>] [--avatar <url>]");
-          process.exit(1);
+          printUsageAndExit(CONTACTS_COMMAND_HELP.update);
         }
         const nicknameIdx = args.indexOf("--nickname");
         const avatarIdx = args.indexOf("--avatar");
@@ -251,34 +330,15 @@ async function main() {
       }
 
       default:
-        console.log(`Usage: contacts.ts <command>
-
-Commands:
-  list                     List all contacts
-  self                     Show your profile
-  get ~ship                Get a contact's profile
-  sync ~ship [~ship2 ...]   Sync profiles
-  add ~ship                Add a contact
-  remove ~ship             Remove a contact
-  update ~ship --nickname <name> --avatar <url>
-                           Update a contact's metadata
-  update-profile [options] Update your profile
-
-Examples:
-  npx ts-node scripts/contacts.ts list
-  npx ts-node scripts/contacts.ts get ~sampel-palnet
-  npx ts-node scripts/contacts.ts update-profile --nickname "New Name"
-`);
-        process.exit(1);
+        printUsageAndExit(CONTACTS_HELP);
     }
 
     if (result) {
       console.log(JSON.stringify(result, null, 2));
     }
     process.exit(0);
-  } catch (error: any) {
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
+  } catch (error) {
+    printErrorAndExit(error);
   }
 }
 

--- a/scripts/contacts.ts
+++ b/scripts/contacts.ts
@@ -23,7 +23,6 @@ import {
   printErrorAndExit,
   printHelpAndExit,
   printUsageAndExit,
-  wantsHelp,
 } from "./cli-utils";
 
 interface ContactEditField {
@@ -69,6 +68,10 @@ const CONTACTS_COMMAND_HELP: Record<string, string> = {
 
 function getContactsHelp(command?: string): string {
   return command ? CONTACTS_COMMAND_HELP[command] ?? CONTACTS_HELP : CONTACTS_HELP;
+}
+
+function isContactsHelpRequest(args: string[]): boolean {
+  return args.length === 2 && isHelpArg(args[1]);
 }
 
 function validateContactsArgs(args: string[]): void {
@@ -253,7 +256,7 @@ async function main() {
       printHelpAndExit(CONTACTS_HELP);
     }
 
-    if (wantsHelp(args.slice(1))) {
+    if (isContactsHelpRequest(args)) {
       printHelpAndExit(getContactsHelp(command));
     }
 

--- a/scripts/dms.ts
+++ b/scripts/dms.ts
@@ -60,6 +60,17 @@ function getDmsHelp(command?: string): string {
   return command ? DMS_COMMAND_HELP[command] ?? DMS_HELP : DMS_HELP;
 }
 
+function isDmsMessageHelpLiteral(args: string[]): boolean {
+  const command = args[0];
+  if (command === "send") {
+    return !!args[1] && wantsHelp(args.slice(2));
+  }
+  if (command === "reply") {
+    return !!args[1] && !!args[2] && wantsHelp(args.slice(3));
+  }
+  return false;
+}
+
 function validateDmsArgs(args: string[]): void {
   const command = args[0];
   if (!command || !DMS_COMMAND_HELP[command]) {
@@ -72,7 +83,7 @@ function validateDmsArgs(args: string[]): void {
       const message = args.slice(2).join(" ");
       if (!clubId || !message) printUsageAndExit(DMS_COMMAND_HELP.send);
       if (!isClub(clubId)) {
-        printUsageAndExit("Error: send only supports group DMs (club IDs starting with 0v)");
+        printErrorAndExit("send only supports group DMs (club IDs starting with 0v)");
       }
       return;
     }
@@ -82,7 +93,7 @@ function validateDmsArgs(args: string[]): void {
       const message = args.slice(3).join(" ");
       if (!clubId || !postId || !message) printUsageAndExit(DMS_COMMAND_HELP.reply);
       if (!isClub(clubId)) {
-        printUsageAndExit("Error: reply only supports group DMs (club IDs starting with 0v)");
+        printErrorAndExit("reply only supports group DMs (club IDs starting with 0v)");
       }
       return;
     }
@@ -295,7 +306,7 @@ async function main() {
     printHelpAndExit(DMS_HELP);
   }
 
-  if (wantsHelp(args.slice(1))) {
+  if (wantsHelp(args.slice(1)) && !isDmsMessageHelpLiteral(args)) {
     printHelpAndExit(getDmsHelp(command));
   }
 
@@ -311,7 +322,7 @@ async function main() {
         printUsageAndExit(DMS_COMMAND_HELP.send);
       }
       if (!isClub(clubId)) {
-        printUsageAndExit("Error: send only supports group DMs (club IDs starting with 0v)");
+        printErrorAndExit("send only supports group DMs (club IDs starting with 0v)");
       }
       const result = await sendClubMessage(clubId, message);
       if (result.success) {
@@ -331,7 +342,7 @@ async function main() {
         printUsageAndExit(DMS_COMMAND_HELP.reply);
       }
       if (!isClub(clubId)) {
-        printUsageAndExit("Error: reply only supports group DMs (club IDs starting with 0v)");
+        printErrorAndExit("reply only supports group DMs (club IDs starting with 0v)");
       }
       const result = await replyToClub(clubId, postId, message);
       if (result.success) {

--- a/scripts/dms.ts
+++ b/scripts/dms.ts
@@ -26,7 +26,82 @@ import {
 } from "@tloncorp/api";
 import type { Channel } from "@tloncorp/api";
 import { ensureClient, normalizeShip } from "./api-client";
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
 import { markdownToStory, type Story } from "./story";
+
+const DMS_HELP = `Usage: tlon dms <command>
+
+Commands:
+  send <club-id> <message>        Send a message to a group DM
+  reply <club-id> <post-id> <msg> Reply in a group DM (post-id must include author)
+  react <ship> <post-id> <emoji>  React to a DM (post-id must include author)
+  unreact <ship> <post-id>        Remove reaction from a DM (post-id must include author)
+  delete <ship> <post-id>         Delete a DM (post-id may include author)
+  accept <ship>                   Accept a DM invite
+  decline <ship>                  Decline a DM invite`;
+
+const DMS_COMMAND_HELP: Record<string, string> = {
+  send: "Usage: tlon dms send <club-id> <message>",
+  reply: "Usage: tlon dms reply <club-id> <post-id> <message>",
+  react: "Usage: tlon dms react <ship> <post-id> <emoji>",
+  unreact: "Usage: tlon dms unreact <ship> <post-id>",
+  delete: "Usage: tlon dms delete <ship> <post-id>",
+  accept: "Usage: tlon dms accept <ship>",
+  decline: "Usage: tlon dms decline <ship>",
+};
+
+function getDmsHelp(command?: string): string {
+  return command ? DMS_COMMAND_HELP[command] ?? DMS_HELP : DMS_HELP;
+}
+
+function validateDmsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !DMS_COMMAND_HELP[command]) {
+    printUsageAndExit(DMS_HELP);
+  }
+
+  switch (command) {
+    case "send": {
+      const clubId = args[1];
+      const message = args.slice(2).join(" ");
+      if (!clubId || !message) printUsageAndExit(DMS_COMMAND_HELP.send);
+      if (!isClub(clubId)) {
+        printUsageAndExit("Error: send only supports group DMs (club IDs starting with 0v)");
+      }
+      return;
+    }
+    case "reply": {
+      const clubId = args[1];
+      const postId = args[2];
+      const message = args.slice(3).join(" ");
+      if (!clubId || !postId || !message) printUsageAndExit(DMS_COMMAND_HELP.reply);
+      if (!isClub(clubId)) {
+        printUsageAndExit("Error: reply only supports group DMs (club IDs starting with 0v)");
+      }
+      return;
+    }
+    case "react": {
+      if (!args[1] || !args[2] || !args[3]) printUsageAndExit(DMS_COMMAND_HELP.react);
+      return;
+    }
+    case "unreact":
+    case "delete": {
+      if (!args[1] || !args[2]) printUsageAndExit(DMS_COMMAND_HELP[command]);
+      return;
+    }
+    case "accept":
+    case "decline": {
+      if (!args[1]) printUsageAndExit(DMS_COMMAND_HELP[command]);
+      return;
+    }
+  }
+}
 
 // Parse content into Story format with rich markdown support
 function parseContent(message: string): Story {
@@ -216,6 +291,16 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
+  if (isHelpArg(command)) {
+    printHelpAndExit(DMS_HELP);
+  }
+
+  if (wantsHelp(args.slice(1))) {
+    printHelpAndExit(getDmsHelp(command));
+  }
+
+  validateDmsArgs(args);
+
   await ensureClient(['chat']);
 
   switch (command) {
@@ -223,12 +308,10 @@ async function main() {
       const clubId = args[1];
       const message = args.slice(2).join(" ");
       if (!clubId || !message) {
-        console.error("Usage: dms.ts send <club-id> <message>");
-        process.exit(1);
+        printUsageAndExit(DMS_COMMAND_HELP.send);
       }
       if (!isClub(clubId)) {
-        console.error("Error: send only supports group DMs (club IDs starting with 0v)");
-        process.exit(1);
+        printUsageAndExit("Error: send only supports group DMs (club IDs starting with 0v)");
       }
       const result = await sendClubMessage(clubId, message);
       if (result.success) {
@@ -245,12 +328,10 @@ async function main() {
       const postId = args[2];
       const message = args.slice(3).join(" ");
       if (!clubId || !postId || !message) {
-        console.error("Usage: dms.ts reply <club-id> <post-id> <message>");
-        process.exit(1);
+        printUsageAndExit(DMS_COMMAND_HELP.reply);
       }
       if (!isClub(clubId)) {
-        console.error("Error: reply only supports group DMs (club IDs starting with 0v)");
-        process.exit(1);
+        printUsageAndExit("Error: reply only supports group DMs (club IDs starting with 0v)");
       }
       const result = await replyToClub(clubId, postId, message);
       if (result.success) {
@@ -267,8 +348,7 @@ async function main() {
       const postId = args[2];
       const react = args[3];
       if (!ship || !postId || !react) {
-        console.error("Usage: dms.ts react <ship> <post-id> <emoji>");
-        process.exit(1);
+        printUsageAndExit(DMS_COMMAND_HELP.react);
       }
       const result = await reactToDM(ship, postId, react);
       if (result.success) {
@@ -284,8 +364,7 @@ async function main() {
       const ship = args[1];
       const postId = args[2];
       if (!ship || !postId) {
-        console.error("Usage: dms.ts unreact <ship> <post-id>");
-        process.exit(1);
+        printUsageAndExit(DMS_COMMAND_HELP.unreact);
       }
       const result = await unreactToDM(ship, postId);
       if (result.success) {
@@ -301,8 +380,7 @@ async function main() {
       const ship = args[1];
       const postId = args[2];
       if (!ship || !postId) {
-        console.error("Usage: dms.ts delete <ship> <post-id>");
-        process.exit(1);
+        printUsageAndExit(DMS_COMMAND_HELP.delete);
       }
       const result = await deleteDM(ship, postId);
       if (result.success) {
@@ -317,8 +395,7 @@ async function main() {
     case "accept": {
       const ship = args[1];
       if (!ship) {
-        console.error("Usage: dms.ts accept <ship>");
-        process.exit(1);
+        printUsageAndExit(DMS_COMMAND_HELP.accept);
       }
       const result = await acceptDM(ship);
       if (result.success) {
@@ -333,8 +410,7 @@ async function main() {
     case "decline": {
       const ship = args[1];
       if (!ship) {
-        console.error("Usage: dms.ts decline <ship>");
-        process.exit(1);
+        printUsageAndExit(DMS_COMMAND_HELP.decline);
       }
       const result = await declineDM(ship);
       if (result.success) {
@@ -347,23 +423,9 @@ async function main() {
     }
 
     default:
-      console.log(`Usage: dms.ts <command>
-
-Commands:
-  send <club-id> <message>        Send a message to a group DM
-  reply <club-id> <post-id> <msg> Reply in a group DM (post-id must include author)
-  react <ship> <post-id> <emoji>  React to a DM (post-id must include author)
-  unreact <ship> <post-id>        Remove reaction from a DM (post-id must include author)
-  delete <ship> <post-id>         Delete a DM (post-id may include author)
-  accept <ship>                   Accept a DM invite
-  decline <ship>                  Decline a DM invite
-`);
-      process.exit(1);
+      printUsageAndExit(DMS_HELP);
   }
   process.exit(0);
 }
 
-main().catch((err) => {
-  console.error("Error:", err);
-  process.exit(1);
-});
+main().catch(printErrorAndExit);

--- a/scripts/expose.ts
+++ b/scripts/expose.ts
@@ -18,7 +18,63 @@
  */
 
 import { poke, scry } from "@tloncorp/api";
-import { ensureClient, getConfig } from "./api-client";
+import { ensureClient } from "./api-client";
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
+
+const EXPOSE_HELP = `Usage: tlon expose <command>
+
+Manage public exposure of Tlon content via the %expose agent.
+
+Commands:
+  list                    List all exposed content with public URLs
+  show <cite-path>        Expose a post publicly
+  hide <cite-path>        Hide an exposed post
+  check <cite-path>       Check if a post is exposed
+  url <cite-path>         Get the public URL for a post
+
+Cite path formats:
+  Simplified:  chat/~host/channel/170.141...
+               diary/~host/channel/170.141...
+               heap/~host/channel/170.141...
+
+  Full:        /1/chan/chat/~host/channel/msg/170.141...
+               /1/chan/diary/~host/channel/note/170.141...
+               /1/chan/heap/~host/channel/curio/170.141...
+
+Examples:
+  tlon expose list
+  tlon expose show chat/~nocsyx-lassul/my-channel/170.141.184.507...
+  tlon expose hide chat/~nocsyx-lassul/my-channel/170.141.184.507...
+  tlon expose check diary/~nocsyx-lassul/blog/170.141.184.507...
+  tlon expose url diary/~nocsyx-lassul/blog/170.141.184.507...`;
+
+const EXPOSE_COMMAND_HELP: Record<string, string> = {
+  list: "Usage: tlon expose list",
+  show: "Usage: tlon expose show <cite-path>\nExample: tlon expose show chat/~host/channel/170.141...",
+  hide: "Usage: tlon expose hide <cite-path>",
+  check: "Usage: tlon expose check <cite-path>",
+  url: "Usage: tlon expose url <cite-path>",
+};
+
+function getExposeHelp(command?: string): string {
+  return command ? EXPOSE_COMMAND_HELP[command] ?? EXPOSE_HELP : EXPOSE_HELP;
+}
+
+function validateExposeArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !EXPOSE_COMMAND_HELP[command]) {
+    printUsageAndExit(EXPOSE_HELP);
+  }
+  if (command !== "list" && !args[1]) {
+    printUsageAndExit(EXPOSE_COMMAND_HELP[command]);
+  }
+}
 
 // Expand a simplified cite path to full format
 // chat/~host/channel/170.141... -> /1/chan/chat/~host/channel/msg/170.141...
@@ -179,6 +235,16 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
+  if (isHelpArg(command)) {
+    printHelpAndExit(EXPOSE_HELP);
+  }
+
+  if (wantsHelp(args.slice(1))) {
+    printHelpAndExit(getExposeHelp(command));
+  }
+
+  validateExposeArgs(args);
+
   const config = await ensureClient();
 
   try {
@@ -201,9 +267,7 @@ async function main() {
       case "show": {
         const citePath = args[1];
         if (!citePath) {
-          console.error("Usage: tlon expose show <cite-path>");
-          console.error("Example: tlon expose show chat/~host/channel/170.141...");
-          process.exit(1);
+          printUsageAndExit(EXPOSE_COMMAND_HELP.show);
         }
 
         await showPost(citePath);
@@ -217,8 +281,7 @@ async function main() {
       case "hide": {
         const citePath = args[1];
         if (!citePath) {
-          console.error("Usage: tlon expose hide <cite-path>");
-          process.exit(1);
+          printUsageAndExit(EXPOSE_COMMAND_HELP.hide);
         }
 
         await hidePost(citePath);
@@ -229,8 +292,7 @@ async function main() {
       case "check": {
         const citePath = args[1];
         if (!citePath) {
-          console.error("Usage: tlon expose check <cite-path>");
-          process.exit(1);
+          printUsageAndExit(EXPOSE_COMMAND_HELP.check);
         }
 
         const isExposed = await checkExposed(citePath);
@@ -248,8 +310,7 @@ async function main() {
       case "url": {
         const citePath = args[1];
         if (!citePath) {
-          console.error("Usage: tlon expose url <cite-path>");
-          process.exit(1);
+          printUsageAndExit(EXPOSE_COMMAND_HELP.url);
         }
 
         const fullPath = expandCitePath(citePath);
@@ -259,40 +320,12 @@ async function main() {
       }
 
       default:
-        console.log(`Usage: tlon expose <command>
-
-Manage public exposure of Tlon content via the %expose agent.
-
-Commands:
-  list                    List all exposed content with public URLs
-  show <cite-path>        Expose a post publicly
-  hide <cite-path>        Hide an exposed post
-  check <cite-path>       Check if a post is exposed
-  url <cite-path>         Get the public URL for a post
-
-Cite path formats:
-  Simplified:  chat/~host/channel/170.141...
-               diary/~host/channel/170.141...
-               heap/~host/channel/170.141...
-
-  Full:        /1/chan/chat/~host/channel/msg/170.141...
-               /1/chan/diary/~host/channel/note/170.141...
-               /1/chan/heap/~host/channel/curio/170.141...
-
-Examples:
-  tlon expose list
-  tlon expose show chat/~nocsyx-lassul/my-channel/170.141.184.507...
-  tlon expose hide chat/~nocsyx-lassul/my-channel/170.141.184.507...
-  tlon expose check diary/~nocsyx-lassul/blog/170.141.184.507...
-  tlon expose url diary/~nocsyx-lassul/blog/170.141.184.507...
-`);
-        process.exit(command ? 1 : 0);
+        printUsageAndExit(EXPOSE_HELP);
     }
 
     process.exit(0);
-  } catch (error: any) {
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
+  } catch (error) {
+    printErrorAndExit(error);
   }
 }
 

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -77,11 +77,13 @@ import {
   printErrorAndExit,
   printHelpAndExit,
   printUsageAndExit,
-  wantsHelp,
 } from "./cli-utils";
 
 const ADMIN_ROLE_ID = "admin";
+const GROUP_CREATE_FLAGS = ["description"] as const;
+const GROUP_CREATE_OWNED_FLAGS = ["owner", "description"] as const;
 const GROUP_UPDATE_FLAGS = ["title", "description", "image", "cover"] as const;
+const GROUP_ADD_CHANNEL_FLAGS = ["kind", "description"] as const;
 
 // Generate a random short ID for the group
 function generateGroupSlug(): string {
@@ -168,6 +170,17 @@ function getGroupsHelp(command?: string) {
   return command ? GROUPS_COMMAND_HELP[command] ?? GROUPS_HELP : GROUPS_HELP;
 }
 
+function isKnownGroupsOption(
+  arg: string | undefined,
+  optionNames: readonly string[]
+): boolean {
+  return optionNames.some((optionName) => arg === `--${optionName}`);
+}
+
+function isGroupsHelpRequest(args: string[]): boolean {
+  return args.length === 2 && isHelpArg(args[1]);
+}
+
 function validateGroupsArgs(args: string[]): void {
   const command = args[0];
   if (!command || !GROUPS_COMMAND_HELP[command]) {
@@ -179,13 +192,20 @@ function validateGroupsArgs(args: string[]): void {
       return;
     case "create": {
       const title = args[1];
-      if (!title || title.startsWith("--")) printUsageAndExit(GROUPS_COMMAND_HELP.create);
+      if (!title || isKnownGroupsOption(title, GROUP_CREATE_FLAGS)) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.create);
+      }
       return;
     }
     case "create-owned": {
       const title = args[1];
       const owner = getOption(args, "owner");
-      if (!title || title.startsWith("--") || !owner || owner.startsWith("--")) {
+      if (
+        !title ||
+        isKnownGroupsOption(title, GROUP_CREATE_OWNED_FLAGS) ||
+        !owner ||
+        owner.startsWith("--")
+      ) {
         printUsageAndExit(GROUPS_COMMAND_HELP["create-owned"]);
       }
       return;
@@ -250,7 +270,7 @@ function validateGroupsArgs(args: string[]): void {
       return;
     }
     case "add-channel": {
-      if (!args[1] || !args[2] || args[2].startsWith("--")) {
+      if (!args[1] || !args[2] || isKnownGroupsOption(args[2], GROUP_ADD_CHANNEL_FLAGS)) {
         printUsageAndExit(GROUPS_COMMAND_HELP["add-channel"]);
       }
       if (looksLikePositionalChannelKind(args, 2)) {
@@ -1146,7 +1166,7 @@ async function main() {
     printHelpAndExit(GROUPS_HELP);
   }
 
-  if (wantsHelp(args.slice(1))) {
+  if (isGroupsHelpRequest(args)) {
     printHelpAndExit(getGroupsHelp(command));
   }
 
@@ -1172,7 +1192,12 @@ async function main() {
     case "create-owned": {
       const title = args[1];
       const owner = getOption(args, "owner");
-      if (!title || title.startsWith("--") || !owner || owner.startsWith("--")) {
+      if (
+        !title ||
+        isKnownGroupsOption(title, GROUP_CREATE_OWNED_FLAGS) ||
+        !owner ||
+        owner.startsWith("--")
+      ) {
         console.error(GROUPS_COMMAND_HELP["create-owned"]);
         process.exit(1);
       }

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -69,7 +69,15 @@ import {
 } from "@tloncorp/api";
 import type { Group } from "@tloncorp/api";
 import { ensureClient, getCurrentShip, normalizeShip } from "./api-client";
-import { getOption, looksLikePositionalChannelKind, wantsHelp } from "./cli-utils";
+import {
+  getOption,
+  isHelpArg,
+  looksLikePositionalChannelKind,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
 
 const ADMIN_ROLE_ID = "admin";
 
@@ -85,7 +93,7 @@ function generateGroupSlug(): string {
   return slug;
 }
 
-const GROUPS_HELP = `Usage: groups.ts <command>
+const GROUPS_HELP = `Usage: tlon groups <command>
 
 Commands:
   list
@@ -119,43 +127,126 @@ Commands:
   add-channel <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]
 
 Examples:
-  groups.ts info ~host/group-slug
-  groups.ts add-channel ~host/group-slug "Projects" --kind chat`;
+  tlon groups info ~host/group-slug
+  tlon groups add-channel ~host/group-slug "Projects" --kind chat`;
 
 const GROUPS_COMMAND_HELP: Record<string, string> = {
-  list: `Usage: groups.ts list`,
-  create: `Usage: groups.ts create "Group Name" [--description "..."]\nExample: groups.ts create "Projects" --description "Shared work"`,
-  "create-owned": `Usage: groups.ts create-owned "Group Name" --owner <ship> [--description "..."]\nExample: groups.ts create-owned "Projects" --owner ~nec --description "Shared work"`,
-  invite: `Usage: groups.ts invite <group-id> <ship> [<ship2> ...]\nExample: groups.ts invite ~host/group-slug ~nec ~bud`,
-  info: `Usage: groups.ts info <group-id>\nExample: groups.ts info ~host/group-slug`,
-  leave: `Usage: groups.ts leave <group-id>\nExample: groups.ts leave ~host/group-slug`,
-  join: `Usage: groups.ts join <group-id>\nJoins public or invited groups. For private groups without an invite, requests an invite.\nExample: groups.ts join ~host/group-slug`,
-  "request-invite": `Usage: groups.ts request-invite <group-id>\nExample: groups.ts request-invite ~host/group-slug`,
-  "accept-invite": `Usage: groups.ts accept-invite <group-id>\nExample: groups.ts accept-invite ~host/group-slug`,
-  "reject-invite": `Usage: groups.ts reject-invite <group-id>\nExample: groups.ts reject-invite ~host/group-slug`,
-  "cancel-join": `Usage: groups.ts cancel-join <group-id>\nExample: groups.ts cancel-join ~host/group-slug`,
-  "rescind-request": `Usage: groups.ts rescind-request <group-id>\nExample: groups.ts rescind-request ~host/group-slug`,
-  "revoke-invite": `Usage: groups.ts revoke-invite <group-id> <ship> [<ship2> ...]\nExample: groups.ts revoke-invite ~host/group-slug ~nec`,
-  delete: `Usage: groups.ts delete <group-id>\nExample: groups.ts delete ~host/group-slug`,
-  update: `Usage: groups.ts update <group-id> --title "..." [--description "..."] [--image "..."] [--cover "..."]\nExample: groups.ts update ~host/group-slug --title "New Title"`,
-  kick: `Usage: groups.ts kick <group-id> <ship> [<ship2> ...]\nExample: groups.ts kick ~host/group-slug ~nec`,
-  ban: `Usage: groups.ts ban <group-id> <ship> [<ship2> ...]\nExample: groups.ts ban ~host/group-slug ~nec`,
-  unban: `Usage: groups.ts unban <group-id> <ship> [<ship2> ...]\nExample: groups.ts unban ~host/group-slug ~nec`,
-  "add-role": `Usage: groups.ts add-role <group-id> <role-id> --title "..." [--description "..."]\nExample: groups.ts add-role ~host/group-slug editors --title "Editors"`,
-  "delete-role": `Usage: groups.ts delete-role <group-id> <role-id>\nExample: groups.ts delete-role ~host/group-slug editors`,
-  "update-role": `Usage: groups.ts update-role <group-id> <role-id> --title "..." [--description "..."]\nExample: groups.ts update-role ~host/group-slug editors --title "Writers"`,
-  "assign-role": `Usage: groups.ts assign-role <group-id> <role-id> <ship> [<ship2> ...]\nExample: groups.ts assign-role ~host/group-slug editors ~nec`,
-  "remove-role": `Usage: groups.ts remove-role <group-id> <role-id> <ship> [<ship2> ...]\nExample: groups.ts remove-role ~host/group-slug editors ~nec`,
-  "set-privacy": `Usage: groups.ts set-privacy <group-id> <public|private|secret>\nExample: groups.ts set-privacy ~host/group-slug private`,
-  "accept-join": `Usage: groups.ts accept-join <group-id> <ship> [<ship2> ...]\nExample: groups.ts accept-join ~host/group-slug ~nec`,
-  "reject-join": `Usage: groups.ts reject-join <group-id> <ship> [<ship2> ...]\nExample: groups.ts reject-join ~host/group-slug ~nec`,
-  promote: `Usage: groups.ts promote <group-id> <ship> [<ship2> ...]\nExample: groups.ts promote ~host/group-slug ~nec`,
-  demote: `Usage: groups.ts demote <group-id> <ship> [<ship2> ...]\nExample: groups.ts demote ~host/group-slug ~nec`,
-  "add-channel": `Usage: groups.ts add-channel <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]\nExample: groups.ts add-channel ~host/group-slug "Projects" --kind chat`,
+  list: `Usage: tlon groups list`,
+  create: `Usage: tlon groups create "Group Name" [--description "..."]\nExample: tlon groups create "Projects" --description "Shared work"`,
+  "create-owned": `Usage: tlon groups create-owned "Group Name" --owner <ship> [--description "..."]\nExample: tlon groups create-owned "Projects" --owner ~nec --description "Shared work"`,
+  invite: `Usage: tlon groups invite <group-id> <ship> [<ship2> ...]\nExample: tlon groups invite ~host/group-slug ~nec ~bud`,
+  info: `Usage: tlon groups info <group-id>\nExample: tlon groups info ~host/group-slug`,
+  leave: `Usage: tlon groups leave <group-id>\nExample: tlon groups leave ~host/group-slug`,
+  join: `Usage: tlon groups join <group-id>\nJoins public or invited groups. For private groups without an invite, requests an invite.\nExample: tlon groups join ~host/group-slug`,
+  "request-invite": `Usage: tlon groups request-invite <group-id>\nExample: tlon groups request-invite ~host/group-slug`,
+  "accept-invite": `Usage: tlon groups accept-invite <group-id>\nExample: tlon groups accept-invite ~host/group-slug`,
+  "reject-invite": `Usage: tlon groups reject-invite <group-id>\nExample: tlon groups reject-invite ~host/group-slug`,
+  "cancel-join": `Usage: tlon groups cancel-join <group-id>\nExample: tlon groups cancel-join ~host/group-slug`,
+  "rescind-request": `Usage: tlon groups rescind-request <group-id>\nExample: tlon groups rescind-request ~host/group-slug`,
+  "revoke-invite": `Usage: tlon groups revoke-invite <group-id> <ship> [<ship2> ...]\nExample: tlon groups revoke-invite ~host/group-slug ~nec`,
+  delete: `Usage: tlon groups delete <group-id>\nExample: tlon groups delete ~host/group-slug`,
+  update: `Usage: tlon groups update <group-id> --title "..." [--description "..."] [--image "..."] [--cover "..."]\nExample: tlon groups update ~host/group-slug --title "New Title"`,
+  kick: `Usage: tlon groups kick <group-id> <ship> [<ship2> ...]\nExample: tlon groups kick ~host/group-slug ~nec`,
+  ban: `Usage: tlon groups ban <group-id> <ship> [<ship2> ...]\nExample: tlon groups ban ~host/group-slug ~nec`,
+  unban: `Usage: tlon groups unban <group-id> <ship> [<ship2> ...]\nExample: tlon groups unban ~host/group-slug ~nec`,
+  "add-role": `Usage: tlon groups add-role <group-id> <role-id> --title "..." [--description "..."]\nExample: tlon groups add-role ~host/group-slug editors --title "Editors"`,
+  "delete-role": `Usage: tlon groups delete-role <group-id> <role-id>\nExample: tlon groups delete-role ~host/group-slug editors`,
+  "update-role": `Usage: tlon groups update-role <group-id> <role-id> --title "..." [--description "..."]\nExample: tlon groups update-role ~host/group-slug editors --title "Writers"`,
+  "assign-role": `Usage: tlon groups assign-role <group-id> <role-id> <ship> [<ship2> ...]\nExample: tlon groups assign-role ~host/group-slug editors ~nec`,
+  "remove-role": `Usage: tlon groups remove-role <group-id> <role-id> <ship> [<ship2> ...]\nExample: tlon groups remove-role ~host/group-slug editors ~nec`,
+  "set-privacy": `Usage: tlon groups set-privacy <group-id> <public|private|secret>\nExample: tlon groups set-privacy ~host/group-slug private`,
+  "accept-join": `Usage: tlon groups accept-join <group-id> <ship> [<ship2> ...]\nExample: tlon groups accept-join ~host/group-slug ~nec`,
+  "reject-join": `Usage: tlon groups reject-join <group-id> <ship> [<ship2> ...]\nExample: tlon groups reject-join ~host/group-slug ~nec`,
+  promote: `Usage: tlon groups promote <group-id> <ship> [<ship2> ...]\nExample: tlon groups promote ~host/group-slug ~nec`,
+  demote: `Usage: tlon groups demote <group-id> <ship> [<ship2> ...]\nExample: tlon groups demote ~host/group-slug ~nec`,
+  "add-channel": `Usage: tlon groups add-channel <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]\nExample: tlon groups add-channel ~host/group-slug "Projects" --kind chat`,
 };
 
-function printGroupsHelp(command?: string) {
-  console.log(command ? GROUPS_COMMAND_HELP[command] ?? GROUPS_HELP : GROUPS_HELP);
+function getGroupsHelp(command?: string) {
+  return command ? GROUPS_COMMAND_HELP[command] ?? GROUPS_HELP : GROUPS_HELP;
+}
+
+function validateGroupsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !GROUPS_COMMAND_HELP[command]) {
+    printUsageAndExit(GROUPS_HELP);
+  }
+
+  switch (command) {
+    case "list":
+      return;
+    case "create": {
+      const title = args[1];
+      if (!title || title.startsWith("--")) printUsageAndExit(GROUPS_COMMAND_HELP.create);
+      return;
+    }
+    case "create-owned": {
+      const title = args[1];
+      const owner = getOption(args, "owner");
+      if (!title || title.startsWith("--") || !owner || owner.startsWith("--")) {
+        printUsageAndExit(GROUPS_COMMAND_HELP["create-owned"]);
+      }
+      return;
+    }
+    case "info":
+    case "leave":
+    case "join":
+    case "request-invite":
+    case "accept-invite":
+    case "reject-invite":
+    case "cancel-join":
+    case "rescind-request":
+    case "delete":
+    case "update": {
+      if (!args[1]) printUsageAndExit(GROUPS_COMMAND_HELP[command]);
+      return;
+    }
+    case "invite":
+    case "revoke-invite":
+    case "kick":
+    case "ban":
+    case "unban":
+    case "accept-join":
+    case "reject-join":
+    case "promote":
+    case "demote": {
+      if (!args[1] || args.slice(2).length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP[command]);
+      }
+      return;
+    }
+    case "add-role":
+    case "delete-role":
+    case "update-role": {
+      if (!args[1] || !args[2]) printUsageAndExit(GROUPS_COMMAND_HELP[command]);
+      return;
+    }
+    case "assign-role":
+    case "remove-role": {
+      if (!args[1] || !args[2] || args.slice(3).length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP[command]);
+      }
+      return;
+    }
+    case "set-privacy": {
+      const privacy = args[2];
+      if (!args[1] || !privacy || !["public", "private", "secret"].includes(privacy)) {
+        printUsageAndExit(GROUPS_COMMAND_HELP["set-privacy"]);
+      }
+      return;
+    }
+    case "add-channel": {
+      if (!args[1] || !args[2] || args[2].startsWith("--")) {
+        printUsageAndExit(GROUPS_COMMAND_HELP["add-channel"]);
+      }
+      if (looksLikePositionalChannelKind(args, 2)) {
+        printUsageAndExit(
+          `Error: channel kind must be passed with --kind, not as a positional argument.\n${GROUPS_COMMAND_HELP["add-channel"]}`
+        );
+      }
+      return;
+    }
+  }
 }
 
 // List all groups
@@ -1037,15 +1128,15 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
-  if (!command || command === "--help" || command === "-h") {
-    printGroupsHelp();
-    process.exit(0);
+  if (isHelpArg(command)) {
+    printHelpAndExit(GROUPS_HELP);
   }
 
   if (wantsHelp(args.slice(1))) {
-    printGroupsHelp(command);
-    process.exit(0);
+    printHelpAndExit(getGroupsHelp(command));
   }
+
+  validateGroupsArgs(args);
 
   await ensureClient(['groups', 'channels']);
 
@@ -1057,8 +1148,7 @@ async function main() {
     case "create": {
       const title = args[1];
       if (!title) {
-        console.error('Usage: groups.ts create "Group Name" [--description "..."]');
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.create);
       }
       const description = getOption(args, "description") || "";
       await createGroupWithChannel(title, description);
@@ -1081,8 +1171,7 @@ async function main() {
       const groupId = args[1];
       const ships = args.slice(2);
       if (!groupId || ships.length === 0) {
-        console.error("Usage: groups.ts invite <group-id> <ship> [<ship2> ...]");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.invite);
       }
       await inviteToGroup(groupId, ships);
       break;
@@ -1091,8 +1180,7 @@ async function main() {
     case "info": {
       const groupId = args[1];
       if (!groupId) {
-        console.error("Usage: groups.ts info <group-id>");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.info);
       }
       await getGroupInfo(groupId);
       break;
@@ -1101,8 +1189,7 @@ async function main() {
     case "leave": {
       const groupId = args[1];
       if (!groupId) {
-        console.error("Usage: groups.ts leave <group-id>");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.leave);
       }
       await leaveGroupById(groupId);
       break;
@@ -1182,8 +1269,7 @@ async function main() {
     case "delete": {
       const groupId = args[1];
       if (!groupId) {
-        console.error("Usage: groups.ts delete <group-id>");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.delete);
       }
       await deleteGroupById(groupId);
       break;
@@ -1192,10 +1278,7 @@ async function main() {
     case "update": {
       const groupId = args[1];
       if (!groupId) {
-        console.error(
-          'Usage: groups.ts update <group-id> --title "..." [--description "..."] [--image "..."]'
-        );
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.update);
       }
       const title = getOption(args, "title");
       const description = getOption(args, "description");
@@ -1209,8 +1292,7 @@ async function main() {
       const groupId = args[1];
       const ships = args.slice(2);
       if (!groupId || ships.length === 0) {
-        console.error("Usage: groups.ts kick <group-id> <ship> [<ship2> ...]");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.kick);
       }
       await kickMembers(groupId, ships);
       break;
@@ -1220,8 +1302,7 @@ async function main() {
       const groupId = args[1];
       const ships = args.slice(2);
       if (!groupId || ships.length === 0) {
-        console.error("Usage: groups.ts ban <group-id> <ship> [<ship2> ...]");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.ban);
       }
       await banMembers(groupId, ships);
       break;
@@ -1231,8 +1312,7 @@ async function main() {
       const groupId = args[1];
       const ships = args.slice(2);
       if (!groupId || ships.length === 0) {
-        console.error("Usage: groups.ts unban <group-id> <ship> [<ship2> ...]");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.unban);
       }
       await unbanMembers(groupId, ships);
       break;
@@ -1242,10 +1322,7 @@ async function main() {
       const groupId = args[1];
       const roleId = args[2];
       if (!groupId || !roleId) {
-        console.error(
-          'Usage: groups.ts add-role <group-id> <role-id> --title "..." [--description "..."]'
-        );
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP["add-role"]);
       }
       const title = getOption(args, "title");
       const description = getOption(args, "description");
@@ -1257,8 +1334,7 @@ async function main() {
       const groupId = args[1];
       const roleId = args[2];
       if (!groupId || !roleId) {
-        console.error("Usage: groups.ts delete-role <group-id> <role-id>");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP["delete-role"]);
       }
       await deleteRole(groupId, roleId);
       break;
@@ -1268,10 +1344,7 @@ async function main() {
       const groupId = args[1];
       const roleId = args[2];
       if (!groupId || !roleId) {
-        console.error(
-          'Usage: groups.ts update-role <group-id> <role-id> --title "..." [--description "..."]'
-        );
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP["update-role"]);
       }
       const title = getOption(args, "title");
       const description = getOption(args, "description");
@@ -1284,10 +1357,7 @@ async function main() {
       const roleId = args[2];
       const ships = args.slice(3);
       if (!groupId || !roleId || ships.length === 0) {
-        console.error(
-          "Usage: groups.ts assign-role <group-id> <role-id> <ship> [<ship2> ...]"
-        );
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP["assign-role"]);
       }
       await assignRole(groupId, roleId, ships);
       break;
@@ -1298,10 +1368,7 @@ async function main() {
       const roleId = args[2];
       const ships = args.slice(3);
       if (!groupId || !roleId || ships.length === 0) {
-        console.error(
-          "Usage: groups.ts remove-role <group-id> <role-id> <ship> [<ship2> ...]"
-        );
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP["remove-role"]);
       }
       await removeRole(groupId, roleId, ships);
       break;
@@ -1311,8 +1378,7 @@ async function main() {
       const groupId = args[1];
       const privacy = args[2] as "public" | "private" | "secret";
       if (!groupId || !privacy || !["public", "private", "secret"].includes(privacy)) {
-        console.error("Usage: groups.ts set-privacy <group-id> <public|private|secret>");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP["set-privacy"]);
       }
       await setGroupPrivacy(groupId, privacy);
       break;
@@ -1322,8 +1388,7 @@ async function main() {
       const groupId = args[1];
       const ships = args.slice(2);
       if (!groupId || ships.length === 0) {
-        console.error("Usage: groups.ts accept-join <group-id> <ship> [<ship2> ...]");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP["accept-join"]);
       }
       await acceptJoin(groupId, ships);
       break;
@@ -1333,8 +1398,7 @@ async function main() {
       const groupId = args[1];
       const ships = args.slice(2);
       if (!groupId || ships.length === 0) {
-        console.error("Usage: groups.ts reject-join <group-id> <ship> [<ship2> ...]");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP["reject-join"]);
       }
       await rejectJoin(groupId, ships);
       break;
@@ -1344,8 +1408,7 @@ async function main() {
       const groupId = args[1];
       const ships = args.slice(2);
       if (!groupId || ships.length === 0) {
-        console.error("Usage: groups.ts promote <group-id> <ship> [<ship2> ...]");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.promote);
       }
       await promoteMemberToAdmin(groupId, ships);
       break;
@@ -1355,8 +1418,7 @@ async function main() {
       const groupId = args[1];
       const ships = args.slice(2);
       if (!groupId || ships.length === 0) {
-        console.error("Usage: groups.ts demote <group-id> <ship> [<ship2> ...]");
-        process.exit(1);
+        printUsageAndExit(GROUPS_COMMAND_HELP.demote);
       }
       await demoteMemberFromAdmin(groupId, ships);
       break;
@@ -1381,13 +1443,9 @@ async function main() {
     }
 
     default:
-      printGroupsHelp();
-      process.exit(1);
+      printUsageAndExit(GROUPS_HELP);
   }
   process.exit(0);
 }
 
-main().catch((err) => {
-  console.error("Error:", err);
-  process.exit(1);
-});
+main().catch(printErrorAndExit);

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -71,6 +71,7 @@ import type { Group } from "@tloncorp/api";
 import { ensureClient, getCurrentShip, normalizeShip } from "./api-client";
 import {
   getOption,
+  hasOptionValue,
   isHelpArg,
   looksLikePositionalChannelKind,
   printErrorAndExit,
@@ -80,6 +81,7 @@ import {
 } from "./cli-utils";
 
 const ADMIN_ROLE_ID = "admin";
+const GROUP_UPDATE_FLAGS = ["title", "description", "image", "cover"] as const;
 
 // Generate a random short ID for the group
 function generateGroupSlug(): string {
@@ -196,9 +198,21 @@ function validateGroupsArgs(args: string[]): void {
     case "reject-invite":
     case "cancel-join":
     case "rescind-request":
-    case "delete":
-    case "update": {
+    case "delete": {
       if (!args[1]) printUsageAndExit(GROUPS_COMMAND_HELP[command]);
+      return;
+    }
+    case "update": {
+      if (!args[1]) printUsageAndExit(GROUPS_COMMAND_HELP.update);
+      if (
+        !GROUP_UPDATE_FLAGS.some((flag) =>
+          hasOptionValue(args, flag, GROUP_UPDATE_FLAGS)
+        )
+      ) {
+        printUsageAndExit(
+          `Error: At least one of --title, --description, --image, or --cover is required\n${GROUPS_COMMAND_HELP.update}`
+        );
+      }
       return;
     }
     case "invite":

--- a/scripts/groups.ts
+++ b/scripts/groups.ts
@@ -73,6 +73,7 @@ import {
   getOption,
   hasOptionValue,
   isHelpArg,
+  isSubcommandHelpRequest,
   looksLikePositionalChannelKind,
   printErrorAndExit,
   printHelpAndExit,
@@ -80,10 +81,7 @@ import {
 } from "./cli-utils";
 
 const ADMIN_ROLE_ID = "admin";
-const GROUP_CREATE_FLAGS = ["description"] as const;
-const GROUP_CREATE_OWNED_FLAGS = ["owner", "description"] as const;
 const GROUP_UPDATE_FLAGS = ["title", "description", "image", "cover"] as const;
-const GROUP_ADD_CHANNEL_FLAGS = ["kind", "description"] as const;
 
 // Generate a random short ID for the group
 function generateGroupSlug(): string {
@@ -170,17 +168,6 @@ function getGroupsHelp(command?: string) {
   return command ? GROUPS_COMMAND_HELP[command] ?? GROUPS_HELP : GROUPS_HELP;
 }
 
-function isKnownGroupsOption(
-  arg: string | undefined,
-  optionNames: readonly string[]
-): boolean {
-  return optionNames.some((optionName) => arg === `--${optionName}`);
-}
-
-function isGroupsHelpRequest(args: string[]): boolean {
-  return args.length === 2 && isHelpArg(args[1]);
-}
-
 function validateGroupsArgs(args: string[]): void {
   const command = args[0];
   if (!command || !GROUPS_COMMAND_HELP[command]) {
@@ -192,20 +179,15 @@ function validateGroupsArgs(args: string[]): void {
       return;
     case "create": {
       const title = args[1];
-      if (!title || isKnownGroupsOption(title, GROUP_CREATE_FLAGS)) {
+      if (title === undefined) {
         printUsageAndExit(GROUPS_COMMAND_HELP.create);
       }
       return;
     }
     case "create-owned": {
       const title = args[1];
-      const owner = getOption(args, "owner");
-      if (
-        !title ||
-        isKnownGroupsOption(title, GROUP_CREATE_OWNED_FLAGS) ||
-        !owner ||
-        owner.startsWith("--")
-      ) {
+      const owner = getOption(args, "owner", 2);
+      if (title === undefined || !owner || owner.startsWith("--")) {
         printUsageAndExit(GROUPS_COMMAND_HELP["create-owned"]);
       }
       return;
@@ -270,7 +252,7 @@ function validateGroupsArgs(args: string[]): void {
       return;
     }
     case "add-channel": {
-      if (!args[1] || !args[2] || isKnownGroupsOption(args[2], GROUP_ADD_CHANNEL_FLAGS)) {
+      if (!args[1] || args[2] === undefined) {
         printUsageAndExit(GROUPS_COMMAND_HELP["add-channel"]);
       }
       if (looksLikePositionalChannelKind(args, 2)) {
@@ -1166,7 +1148,7 @@ async function main() {
     printHelpAndExit(GROUPS_HELP);
   }
 
-  if (isGroupsHelpRequest(args)) {
+  if (isSubcommandHelpRequest(args)) {
     printHelpAndExit(getGroupsHelp(command));
   }
 
@@ -1181,27 +1163,22 @@ async function main() {
 
     case "create": {
       const title = args[1];
-      if (!title) {
+      if (title === undefined) {
         printUsageAndExit(GROUPS_COMMAND_HELP.create);
       }
-      const description = getOption(args, "description") || "";
+      const description = getOption(args, "description", 2) || "";
       await createGroupWithChannel(title, description);
       break;
     }
 
     case "create-owned": {
       const title = args[1];
-      const owner = getOption(args, "owner");
-      if (
-        !title ||
-        isKnownGroupsOption(title, GROUP_CREATE_OWNED_FLAGS) ||
-        !owner ||
-        owner.startsWith("--")
-      ) {
+      const owner = getOption(args, "owner", 2);
+      if (title === undefined || !owner || owner.startsWith("--")) {
         console.error(GROUPS_COMMAND_HELP["create-owned"]);
         process.exit(1);
       }
-      const description = getOption(args, "description") || "";
+      const description = getOption(args, "description", 2) || "";
       await createOwnedGroup(title, owner, description);
       break;
     }
@@ -1466,7 +1443,7 @@ async function main() {
     case "add-channel": {
       const groupId = args[1];
       const title = args[2];
-      if (!groupId || !title) {
+      if (!groupId || title === undefined) {
         console.error(GROUPS_COMMAND_HELP["add-channel"]);
         process.exit(1);
       }
@@ -1475,8 +1452,8 @@ async function main() {
         console.error(GROUPS_COMMAND_HELP["add-channel"]);
         process.exit(1);
       }
-      const kind = (getOption(args, "kind") as "chat" | "diary" | "heap") || "chat";
-      const description = getOption(args, "description") || "";
+      const kind = (getOption(args, "kind", 3) as "chat" | "diary" | "heap") || "chat";
+      const description = getOption(args, "description", 3) || "";
       await addChannel(groupId, title, kind, description);
       break;
     }

--- a/scripts/hooks.ts
+++ b/scripts/hooks.ts
@@ -29,7 +29,6 @@ import {
   printErrorAndExit,
   printHelpAndExit,
   printUsageAndExit,
-  wantsHelp,
 } from "./cli-utils";
 
 // Helper to create a cord (UTF-8 string as little-endian atom) from a JS string
@@ -118,6 +117,10 @@ const HOOKS_COMMAND_HELP: Record<string, string> = {
 
 function getHooksHelp(command?: string): string {
   return command ? HOOKS_COMMAND_HELP[command] ?? HOOKS_HELP : HOOKS_HELP;
+}
+
+function isHooksHelpRequest(args: string[]): boolean {
+  return args.length === 2 && isHelpArg(args[1]);
 }
 
 function validateHooksArgs(args: string[]): void {
@@ -543,7 +546,7 @@ async function main() {
     printHelpAndExit(HOOKS_HELP);
   }
 
-  if (wantsHelp(args.slice(1))) {
+  if (isHooksHelpRequest(args)) {
     printHelpAndExit(getHooksHelp(command));
   }
 

--- a/scripts/hooks.ts
+++ b/scripts/hooks.ts
@@ -557,12 +557,7 @@ async function main() {
       if (!name) {
         printUsageAndExit(HOOKS_COMMAND_HELP.init);
       }
-      const typeRaw = getOption(args, "type") || "on-post";
-      if (!isHookTemplateType(typeRaw)) {
-        printUsageAndExit(
-          `Invalid --type: ${typeRaw}. Expected one of: on-post, cron, moderation, bare`
-        );
-      }
+      const typeRaw = (getOption(args, "type") || "on-post") as HookTemplateType;
       const out = getOption(args, "out");
       const force = hasFlag(args, "force");
       initHookTemplate(name, typeRaw, out, force);

--- a/scripts/hooks.ts
+++ b/scripts/hooks.ts
@@ -72,7 +72,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-type HookTemplateType = "on-post" | "cron" | "moderation" | "bare";
+const HOOK_TEMPLATE_TYPES = ["on-post", "cron", "moderation", "bare"] as const;
+type HookTemplateType = (typeof HOOK_TEMPLATE_TYPES)[number];
+
+function isHookTemplateType(value: string): value is HookTemplateType {
+  return (HOOK_TEMPLATE_TYPES as readonly string[]).includes(value);
+}
 
 const HOOKS_HELP = `Usage: tlon hooks <command>
 
@@ -126,8 +131,8 @@ function validateHooksArgs(args: string[]): void {
       return;
     case "init": {
       if (!args[1]) printUsageAndExit(HOOKS_COMMAND_HELP.init);
-      const typeRaw = (getOption(args, "type") || "on-post") as HookTemplateType;
-      if (!["on-post", "cron", "moderation", "bare"].includes(typeRaw)) {
+      const typeRaw = getOption(args, "type") || "on-post";
+      if (!isHookTemplateType(typeRaw)) {
         printUsageAndExit(
           `Invalid --type: ${typeRaw}. Expected one of: on-post, cron, moderation, bare`
         );
@@ -552,8 +557,8 @@ async function main() {
       if (!name) {
         printUsageAndExit(HOOKS_COMMAND_HELP.init);
       }
-      const typeRaw = (getOption(args, "type") || "on-post") as HookTemplateType;
-      if (!["on-post", "cron", "moderation", "bare"].includes(typeRaw)) {
+      const typeRaw = getOption(args, "type") || "on-post";
+      if (!isHookTemplateType(typeRaw)) {
         printUsageAndExit(
           `Invalid --type: ${typeRaw}. Expected one of: on-post, cron, moderation, bare`
         );

--- a/scripts/hooks.ts
+++ b/scripts/hooks.ts
@@ -25,7 +25,9 @@ import { ensureClient } from "./api-client";
 import {
   getOption,
   hasFlag,
+  hasOptionValue,
   isHelpArg,
+  isSubcommandHelpRequest,
   printErrorAndExit,
   printHelpAndExit,
   printUsageAndExit,
@@ -73,6 +75,7 @@ function sleep(ms: number): Promise<void> {
 
 const HOOK_TEMPLATE_TYPES = ["on-post", "cron", "moderation", "bare"] as const;
 type HookTemplateType = (typeof HOOK_TEMPLATE_TYPES)[number];
+const HOOK_INIT_OPTIONS = ["type", "out", "force"] as const;
 
 function isHookTemplateType(value: string): value is HookTemplateType {
   return (HOOK_TEMPLATE_TYPES as readonly string[]).includes(value);
@@ -119,8 +122,23 @@ function getHooksHelp(command?: string): string {
   return command ? HOOKS_COMMAND_HELP[command] ?? HOOKS_HELP : HOOKS_HELP;
 }
 
-function isHooksHelpRequest(args: string[]): boolean {
-  return args.length === 2 && isHelpArg(args[1]);
+function getHookInitType(args: string[]): HookTemplateType {
+  if (!hasFlag(args, "type")) {
+    return "on-post";
+  }
+
+  if (!hasOptionValue(args, "type", HOOK_INIT_OPTIONS)) {
+    printUsageAndExit(HOOKS_COMMAND_HELP.init);
+  }
+
+  const typeRaw = getOption(args, "type");
+  if (!typeRaw || !isHookTemplateType(typeRaw)) {
+    printUsageAndExit(
+      `Invalid --type: ${typeRaw ?? ""}. Expected one of: on-post, cron, moderation, bare`
+    );
+  }
+
+  return typeRaw;
 }
 
 function validateHooksArgs(args: string[]): void {
@@ -134,12 +152,7 @@ function validateHooksArgs(args: string[]): void {
       return;
     case "init": {
       if (!args[1]) printUsageAndExit(HOOKS_COMMAND_HELP.init);
-      const typeRaw = getOption(args, "type") || "on-post";
-      if (!isHookTemplateType(typeRaw)) {
-        printUsageAndExit(
-          `Invalid --type: ${typeRaw}. Expected one of: on-post, cron, moderation, bare`
-        );
-      }
+      getHookInitType(args);
       return;
     }
     case "get":
@@ -546,7 +559,7 @@ async function main() {
     printHelpAndExit(HOOKS_HELP);
   }
 
-  if (isHooksHelpRequest(args)) {
+  if (isSubcommandHelpRequest(args)) {
     printHelpAndExit(getHooksHelp(command));
   }
 
@@ -560,7 +573,7 @@ async function main() {
       if (!name) {
         printUsageAndExit(HOOKS_COMMAND_HELP.init);
       }
-      const typeRaw = (getOption(args, "type") || "on-post") as HookTemplateType;
+      const typeRaw = getHookInitType(args);
       const out = getOption(args, "out");
       const force = hasFlag(args, "force");
       initHookTemplate(name, typeRaw, out, force);

--- a/scripts/hooks.ts
+++ b/scripts/hooks.ts
@@ -22,7 +22,15 @@ import { poke, scry, subscribe, unsubscribe } from "@tloncorp/api";
 import { Atom, jam } from "@urbit/nockjs";
 import { render } from "@urbit/aura";
 import { ensureClient } from "./api-client";
-import { getOption, hasFlag } from "./cli-utils";
+import {
+  getOption,
+  hasFlag,
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
 
 // Helper to create a cord (UTF-8 string as little-endian atom) from a JS string
 // Atom.fromCord doesnt handle multi-byte UTF-8 (like emojis) correctly
@@ -65,6 +73,97 @@ function sleep(ms: number): Promise<void> {
 }
 
 type HookTemplateType = "on-post" | "cron" | "moderation" | "bare";
+
+const HOOKS_HELP = `Usage: tlon hooks <command>
+
+Commands:
+  init <name> [--type] [--out]      Create a starter hook template
+  list                              List all hooks
+  get <id>                          Get hook details and source
+  add <name> <src-file>             Add a new hook from file
+  edit <id> [--name] [--src]        Edit hook name or source
+  delete <id>                       Delete a hook
+  order <nest> <id1> [id2...]       Set execution order for channel
+  config <id> <nest> <key=value...> Configure hook for channel (values are nouns serialized as text)
+  cron <id> <schedule> [--nest]     Schedule periodic execution
+  rest <id> [--nest]                Stop a cron job
+
+Hook IDs are @uv format (e.g., 0v1a.2b3c4...)
+Schedule is @dr format (e.g., ~h1 for 1 hour, ~m30 for 30 minutes)
+
+Examples:
+  tlon hooks init my-hook --type on-post
+  tlon hooks add my-hook ./my-hook.hoon
+  tlon hooks config 0v1a.2b3c4 chat/~host/channel key1=value1 key2=value2
+  tlon hooks cron 0v1a.2b3c4 ~h1 --nest chat/~host/channel`;
+
+const HOOKS_COMMAND_HELP: Record<string, string> = {
+  init: "Usage: tlon hooks init <name> [--type on-post|cron|moderation|bare] [--out <file>] [--force]",
+  list: "Usage: tlon hooks list",
+  get: "Usage: tlon hooks get <id>",
+  add: "Usage: tlon hooks add <name> <src-file>",
+  edit: "Usage: tlon hooks edit <id> [--name <name>] [--src <file>]",
+  delete: "Usage: tlon hooks delete <id>",
+  del: "Usage: tlon hooks delete <id>",
+  order: "Usage: tlon hooks order <nest> <id1> [id2...]",
+  config: "Usage: tlon hooks config <id> <nest> <key=value...>",
+  cron: "Usage: tlon hooks cron <id> <schedule> [--nest <nest>]\n  schedule: @dr format like ~h1 (1 hour) or ~m30 (30 minutes)",
+  rest: "Usage: tlon hooks rest <id> [--nest <nest>]",
+};
+
+function getHooksHelp(command?: string): string {
+  return command ? HOOKS_COMMAND_HELP[command] ?? HOOKS_HELP : HOOKS_HELP;
+}
+
+function validateHooksArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !HOOKS_COMMAND_HELP[command]) {
+    printUsageAndExit(HOOKS_HELP);
+  }
+
+  switch (command) {
+    case "list":
+      return;
+    case "init": {
+      if (!args[1]) printUsageAndExit(HOOKS_COMMAND_HELP.init);
+      const typeRaw = (getOption(args, "type") || "on-post") as HookTemplateType;
+      if (!["on-post", "cron", "moderation", "bare"].includes(typeRaw)) {
+        printUsageAndExit(
+          `Invalid --type: ${typeRaw}. Expected one of: on-post, cron, moderation, bare`
+        );
+      }
+      return;
+    }
+    case "get":
+    case "edit":
+    case "delete":
+    case "del":
+    case "rest": {
+      if (!args[1]) printUsageAndExit(HOOKS_COMMAND_HELP[command]);
+      return;
+    }
+    case "add": {
+      if (!args[1] || !args[2]) printUsageAndExit(HOOKS_COMMAND_HELP.add);
+      return;
+    }
+    case "order": {
+      const ids = args.slice(2).filter((arg) => !arg.startsWith("--"));
+      if (!args[1] || ids.length === 0) printUsageAndExit(HOOKS_COMMAND_HELP.order);
+      return;
+    }
+    case "config": {
+      const configPairs = args.slice(3).filter((arg) => !arg.startsWith("--"));
+      if (!args[1] || !args[2] || configPairs.length === 0) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.config);
+      }
+      return;
+    }
+    case "cron": {
+      if (!args[1] || !args[2]) printUsageAndExit(HOOKS_COMMAND_HELP.cron);
+      return;
+    }
+  }
+}
 
 function getHookTemplate(name: string, type: HookTemplateType): string {
   const safeName = name.replace(/[^a-zA-Z0-9-_ ]/g, "").trim() || "my-hook";
@@ -435,19 +534,29 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
+  if (isHelpArg(command)) {
+    printHelpAndExit(HOOKS_HELP);
+  }
+
+  if (wantsHelp(args.slice(1))) {
+    printHelpAndExit(getHooksHelp(command));
+  }
+
+  validateHooksArgs(args);
+
   await ensureClient();
 
   switch (command) {
     case "init": {
       const name = args[1];
       if (!name) {
-        console.error("Usage: hooks.ts init <name> [--type on-post|cron|moderation|bare] [--out <file>] [--force]");
-        process.exit(1);
+        printUsageAndExit(HOOKS_COMMAND_HELP.init);
       }
       const typeRaw = (getOption(args, "type") || "on-post") as HookTemplateType;
       if (!["on-post", "cron", "moderation", "bare"].includes(typeRaw)) {
-        console.error(`Invalid --type: ${typeRaw}. Expected one of: on-post, cron, moderation, bare`);
-        process.exit(1);
+        printUsageAndExit(
+          `Invalid --type: ${typeRaw}. Expected one of: on-post, cron, moderation, bare`
+        );
       }
       const out = getOption(args, "out");
       const force = hasFlag(args, "force");
@@ -463,8 +572,7 @@ async function main() {
     case "get": {
       const id = args[1];
       if (!id) {
-        console.error("Usage: hooks.ts get <id>");
-        process.exit(1);
+        printUsageAndExit(HOOKS_COMMAND_HELP.get);
       }
       await getHook(id);
       break;
@@ -474,8 +582,7 @@ async function main() {
       const name = args[1];
       const srcPath = args[2];
       if (!name || !srcPath) {
-        console.error("Usage: hooks.ts add <name> <src-file>");
-        process.exit(1);
+        printUsageAndExit(HOOKS_COMMAND_HELP.add);
       }
       await addHook(name, srcPath);
       break;
@@ -484,8 +591,7 @@ async function main() {
     case "edit": {
       const id = args[1];
       if (!id) {
-        console.error("Usage: hooks.ts edit <id> [--name <name>] [--src <file>]");
-        process.exit(1);
+        printUsageAndExit(HOOKS_COMMAND_HELP.edit);
       }
       const name = getOption(args, "name");
       const srcPath = getOption(args, "src");
@@ -497,8 +603,7 @@ async function main() {
     case "del": {
       const id = args[1];
       if (!id) {
-        console.error("Usage: hooks.ts delete <id>");
-        process.exit(1);
+        printUsageAndExit(HOOKS_COMMAND_HELP.delete);
       }
       await deleteHook(id);
       break;
@@ -508,8 +613,7 @@ async function main() {
       const nest = args[1];
       const ids = args.slice(2).filter((a) => !a.startsWith("--"));
       if (!nest || ids.length === 0) {
-        console.error("Usage: hooks.ts order <nest> <id1> [id2...]");
-        process.exit(1);
+        printUsageAndExit(HOOKS_COMMAND_HELP.order);
       }
       await setOrder(nest, ids);
       break;
@@ -520,8 +624,7 @@ async function main() {
       const nest = args[2];
       const configPairs = args.slice(3).filter((a) => !a.startsWith("--"));
       if (!id || !nest || configPairs.length === 0) {
-        console.error("Usage: hooks.ts config <id> <nest> <key=value...>");
-        process.exit(1);
+        printUsageAndExit(HOOKS_COMMAND_HELP.config);
       }
       const config: Record<string, string> = {};
       for (const pair of configPairs) {
@@ -536,9 +639,7 @@ async function main() {
       const id = args[1];
       const schedule = args[2];
       if (!id || !schedule) {
-        console.error("Usage: hooks.ts cron <id> <schedule> [--nest <nest>]");
-        console.error("  schedule: @dr format like ~h1 (1 hour) or ~m30 (30 minutes)");
-        process.exit(1);
+        printUsageAndExit(HOOKS_COMMAND_HELP.cron);
       }
       const nest = getOption(args, "nest");
       await cronHook(id, schedule, nest);
@@ -548,8 +649,7 @@ async function main() {
     case "rest": {
       const id = args[1];
       if (!id) {
-        console.error("Usage: hooks.ts rest <id> [--nest <nest>]");
-        process.exit(1);
+        printUsageAndExit(HOOKS_COMMAND_HELP.rest);
       }
       const nest = getOption(args, "nest");
       await restHook(id, nest);
@@ -557,36 +657,10 @@ async function main() {
     }
 
     default:
-      console.log(`Usage: hooks.ts <command>
-
-Commands:
-  init <name> [--type] [--out]      Create a starter hook template
-  list                              List all hooks
-  get <id>                          Get hook details and source
-  add <name> <src-file>             Add a new hook from file
-  edit <id> [--name] [--src]        Edit hook name or source
-  delete <id>                       Delete a hook
-  order <nest> <id1> [id2...]       Set execution order for channel
-  config <id> <nest> <key=value...> Configure hook for channel (values are nouns serialized as text)
-  cron <id> <schedule> [--nest]     Schedule periodic execution
-  rest <id> [--nest]                Stop a cron job
-
-Hook IDs are @uv format (e.g., 0v1a.2b3c4...)
-Schedule is @dr format (e.g., ~h1 for 1 hour, ~m30 for 30 minutes)
-
-Examples:
-  tlon hooks init my-hook --type on-post
-  tlon hooks add my-hook ./my-hook.hoon
-  tlon hooks config 0v1a.2b3c4 chat/~host/channel key1=value1 key2=value2
-  tlon hooks cron 0v1a.2b3c4 ~h1 --nest chat/~host/channel
-`);
-      process.exit(1);
+      printUsageAndExit(HOOKS_HELP);
   }
 
   process.exit(0);
 }
 
-main().catch((err) => {
-  console.error("Error:", err.message || err);
-  process.exit(1);
-});
+main().catch(printErrorAndExit);

--- a/scripts/messages.ts
+++ b/scripts/messages.ts
@@ -78,7 +78,7 @@ function validateMessagesArgs(args: string[]): void {
     case "search": {
       const channelIdx = args.indexOf("--channel");
       const channel = channelIdx !== -1 ? args[channelIdx + 1] : undefined;
-      if (!args[1] || !channel || channel.startsWith("--")) {
+      if (!args[1] || args[1].startsWith("--") || !channel || channel.startsWith("--")) {
         printUsageAndExit(MESSAGES_COMMAND_HELP.search);
       }
       return;

--- a/scripts/messages.ts
+++ b/scripts/messages.ts
@@ -62,14 +62,18 @@ function getMessagesHelp(command?: string): string {
   return command ? MESSAGES_COMMAND_HELP[command] ?? MESSAGES_HELP : MESSAGES_HELP;
 }
 
-function hasSearchChannel(args: string[]): boolean {
-  const channelIdx = args.indexOf("--channel");
-  const channel = channelIdx !== -1 ? args[channelIdx + 1] : undefined;
-  return !!channel && !channel.startsWith("--");
+function getSearchChannel(args: string[]): string | undefined {
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === "--channel") {
+      const channel = args[i + 1];
+      return channel && !channel.startsWith("--") ? channel : undefined;
+    }
+  }
+  return undefined;
 }
 
 function isSearchQueryHelpLiteral(args: string[]): boolean {
-  return args[0] === "search" && isHelpArg(args[1]) && hasSearchChannel(args);
+  return args[0] === "search" && isHelpArg(args[1]) && !!getSearchChannel(args);
 }
 
 function validateMessagesArgs(args: string[]): void {
@@ -86,7 +90,7 @@ function validateMessagesArgs(args: string[]): void {
       return;
     }
     case "search": {
-      if (!args[1] || args[1] === "--channel" || !hasSearchChannel(args)) {
+      if (!args[1] || !getSearchChannel(args)) {
         printUsageAndExit(MESSAGES_COMMAND_HELP.search);
       }
       return;
@@ -454,12 +458,7 @@ async function main() {
 
       case "search": {
         const query = args[1];
-        let channel: string | null = null;
-        for (let i = 2; i < args.length; i++) {
-          if (args[i] === "--channel" && args[i + 1]) {
-            channel = args[i + 1];
-          }
-        }
+        const channel = getSearchChannel(args);
 
         if (!query || !channel) {
           printUsageAndExit(MESSAGES_COMMAND_HELP.search);

--- a/scripts/messages.ts
+++ b/scripts/messages.ts
@@ -62,6 +62,16 @@ function getMessagesHelp(command?: string): string {
   return command ? MESSAGES_COMMAND_HELP[command] ?? MESSAGES_HELP : MESSAGES_HELP;
 }
 
+function hasSearchChannel(args: string[]): boolean {
+  const channelIdx = args.indexOf("--channel");
+  const channel = channelIdx !== -1 ? args[channelIdx + 1] : undefined;
+  return !!channel && !channel.startsWith("--");
+}
+
+function isSearchQueryHelpLiteral(args: string[]): boolean {
+  return args[0] === "search" && isHelpArg(args[1]) && hasSearchChannel(args);
+}
+
 function validateMessagesArgs(args: string[]): void {
   const command = args[0];
   if (!command || !MESSAGES_COMMAND_HELP[command]) {
@@ -76,9 +86,7 @@ function validateMessagesArgs(args: string[]): void {
       return;
     }
     case "search": {
-      const channelIdx = args.indexOf("--channel");
-      const channel = channelIdx !== -1 ? args[channelIdx + 1] : undefined;
-      if (!args[1] || args[1].startsWith("--") || !channel || channel.startsWith("--")) {
+      if (!args[1] || args[1] === "--channel" || !hasSearchChannel(args)) {
         printUsageAndExit(MESSAGES_COMMAND_HELP.search);
       }
       return;
@@ -397,7 +405,7 @@ async function main() {
     printHelpAndExit(MESSAGES_HELP);
   }
 
-  if (wantsHelp(args.slice(1))) {
+  if (wantsHelp(args.slice(1)) && !isSearchQueryHelpLiteral(args)) {
     printHelpAndExit(getMessagesHelp(command));
   }
 

--- a/scripts/messages.ts
+++ b/scripts/messages.ts
@@ -24,6 +24,72 @@ import {
 } from "@tloncorp/api";
 import type { ClientPostBlobData, ContentReference, Post } from "@tloncorp/api";
 import { ensureClient, normalizeShip } from "./api-client";
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
+
+const MESSAGES_HELP = `Usage: tlon messages <command>
+
+Commands:
+  dm ~ship                                    Show DM history
+  channel <nest>                              Show channel messages
+  history <nest>                              Alias for channel
+  search "query" --channel <nest>             Search in channel
+  context <channel|~ship> <postId>            Show messages around a post
+  post <channel|~ship> <postId>               Fetch a single post with replies
+
+Examples:
+  tlon messages dm ~sampel-palnet --limit 10
+  tlon messages channel chat/~host/channel-slug --limit 20
+  tlon messages search "hello" --channel chat/~host/slug
+  tlon messages context chat/~host/slug 170.141.184... --limit 5
+  tlon messages post chat/~host/slug 170.141.184...`;
+
+const MESSAGES_COMMAND_HELP: Record<string, string> = {
+  dm: "Usage: tlon messages dm ~ship [--limit N] [--resolve-cites]",
+  channel: "Usage: tlon messages channel chat/~host/slug [--limit N] [--resolve-cites]",
+  history: 'Usage: tlon messages history "chat/~host/channel-slug" [--limit N] [--resolve-cites]',
+  search: 'Usage: tlon messages search "query" --channel chat/~host/slug',
+  context: "Usage: tlon messages context <channel|~ship> <postId> [--limit N] [--resolve-cites]",
+  post: "Usage: tlon messages post <channel|~ship> <postId> [--author ~ship] [--resolve-cites]",
+};
+
+function getMessagesHelp(command?: string): string {
+  return command ? MESSAGES_COMMAND_HELP[command] ?? MESSAGES_HELP : MESSAGES_HELP;
+}
+
+function validateMessagesArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !MESSAGES_COMMAND_HELP[command]) {
+    printUsageAndExit(MESSAGES_HELP);
+  }
+
+  switch (command) {
+    case "dm":
+    case "channel":
+    case "history": {
+      if (!args[1]) printUsageAndExit(MESSAGES_COMMAND_HELP[command]);
+      return;
+    }
+    case "search": {
+      const channelIdx = args.indexOf("--channel");
+      const channel = channelIdx !== -1 ? args[channelIdx + 1] : undefined;
+      if (!args[1] || !channel || channel.startsWith("--")) {
+        printUsageAndExit(MESSAGES_COMMAND_HELP.search);
+      }
+      return;
+    }
+    case "context":
+    case "post": {
+      if (!args[1] || !args[2]) printUsageAndExit(MESSAGES_COMMAND_HELP[command]);
+      return;
+    }
+  }
+}
 
 // Extract text content from a Story
 function extractText(content: any): string {
@@ -327,6 +393,16 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
+  if (isHelpArg(command)) {
+    printHelpAndExit(MESSAGES_HELP);
+  }
+
+  if (wantsHelp(args.slice(1))) {
+    printHelpAndExit(getMessagesHelp(command));
+  }
+
+  validateMessagesArgs(args);
+
   await ensureClient();
 
   // Parse --limit flag
@@ -344,10 +420,7 @@ async function main() {
       case "dm": {
         const ship = args[1];
         if (!ship) {
-          console.log(
-            "Usage: npx ts-node scripts/messages.ts dm ~ship [--limit N] [--resolve-cites]"
-          );
-          process.exit(1);
+          printUsageAndExit(MESSAGES_COMMAND_HELP.dm);
         }
         await fetchDmMessages(ship, limit, resolveCites);
         break;
@@ -356,10 +429,7 @@ async function main() {
       case "channel": {
         const channelPath = args[1];
         if (!channelPath) {
-          console.log(
-            "Usage: npx ts-node scripts/messages.ts channel chat/~host/slug [--limit N] [--resolve-cites]"
-          );
-          process.exit(1);
+          printUsageAndExit(MESSAGES_COMMAND_HELP.channel);
         }
         await fetchMessages(channelPath, limit, resolveCites);
         break;
@@ -368,10 +438,7 @@ async function main() {
       case "history": {
         const channelPath = args[1];
         if (!channelPath) {
-          console.log(
-            "Usage: npx ts-node scripts/messages.ts history \"chat/~host/channel-slug\" [--limit N] [--resolve-cites]"
-          );
-          process.exit(1);
+          printUsageAndExit(MESSAGES_COMMAND_HELP.history);
         }
         await fetchMessages(channelPath, limit, resolveCites);
         break;
@@ -387,10 +454,7 @@ async function main() {
         }
 
         if (!query || !channel) {
-          console.log(
-            'Usage: npx ts-node scripts/messages.ts search "query" --channel chat/~host/slug'
-          );
-          process.exit(1);
+          printUsageAndExit(MESSAGES_COMMAND_HELP.search);
         }
         await searchMessages(query, channel);
         break;
@@ -400,10 +464,7 @@ async function main() {
         const target = args[1];
         const postId = args[2];
         if (!target || !postId) {
-          console.log(
-            "Usage: messages.ts context <channel|~ship> <postId> [--limit N] [--resolve-cites]"
-          );
-          process.exit(1);
+          printUsageAndExit(MESSAGES_COMMAND_HELP.context);
         }
         await fetchContext(target, postId, limit, resolveCites);
         break;
@@ -413,10 +474,7 @@ async function main() {
         const target = args[1];
         const postId = args[2];
         if (!target || !postId) {
-          console.log(
-            "Usage: messages.ts post <channel|~ship> <postId> [--author ~ship] [--resolve-cites]"
-          );
-          process.exit(1);
+          printUsageAndExit(MESSAGES_COMMAND_HELP.post);
         }
         let author: string | undefined;
         const authorIdx = args.indexOf("--author");
@@ -428,29 +486,11 @@ async function main() {
       }
 
       default:
-        console.log(`Usage: messages.ts <command>
-
-Commands:
-  dm ~ship                                    Show DM history
-  channel <nest>                              Show channel messages
-  history <nest>                              Alias for channel
-  search "query" --channel <nest>             Search in channel
-  context <channel|~ship> <postId>            Show messages around a post
-  post <channel|~ship> <postId>               Fetch a single post with replies
-
-Examples:
-  npx ts-node scripts/messages.ts dm ~sampel-palnet --limit 10
-  npx ts-node scripts/messages.ts channel chat/~host/channel-slug --limit 20
-  npx ts-node scripts/messages.ts search "hello" --channel chat/~host/slug
-  npx ts-node scripts/messages.ts context chat/~host/slug 170.141.184... --limit 5
-  npx ts-node scripts/messages.ts post chat/~host/slug 170.141.184...
-`);
-        process.exit(1);
+        printUsageAndExit(MESSAGES_HELP);
     }
     process.exit(0);
-  } catch (error: any) {
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
+  } catch (error) {
+    printErrorAndExit(error);
   }
 }
 

--- a/scripts/notebook-post.ts
+++ b/scripts/notebook-post.ts
@@ -21,7 +21,13 @@ import * as fs from "fs";
 import { getCurrentUserId, sendPost } from "@tloncorp/api";
 import type { Story } from "@tloncorp/api";
 import { ensureClient } from "./api-client";
-import { getRequiredOptionValue } from "./cli-utils";
+import {
+  getRequiredOptionValue,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
 import { normalizeNotebookContent, type NotebookStory } from "./notebook-content";
 import { markdownToStory } from "./story";
 
@@ -30,6 +36,27 @@ interface PostResult {
   error?: string;
   messageId?: string;
 }
+
+const NOTEBOOK_HELP = `Usage: tlon notebook <nest> <title> [options]
+
+Arguments:
+  nest    Diary channel nest (e.g., diary/~host/channel-name)
+  title   Post title
+
+Options:
+  --image <url>     Cover image URL
+  --content <file>  JSON file with Story JSON
+  --stdin           Read Story JSON from stdin
+  --markdown <file> Markdown file to convert to Story
+  --markdown-stdin  Read Markdown from stdin
+
+If no content is provided, creates a post with a title and empty body.
+
+Examples:
+  tlon notebook diary/~host/notes "Hello World"
+  tlon notebook diary/~host/notes "My Post" --image https://example.com/img.png
+  echo '[{"inline":["Hello!"]}]' | tlon notebook diary/~host/notes "Test" --stdin
+  tlon notebook diary/~host/notes "Markdown Post" --markdown post.md`;
 
 function toApiStory(content: NotebookStory): Story {
   return content as unknown as Story;
@@ -68,29 +95,12 @@ export async function postToNotebook(
 async function main() {
   const args = process.argv.slice(2);
 
-  if (args.length < 2 || args.includes("--help") || args.includes("-h")) {
-    console.log(`Usage: npx ts-node scripts/notebook-post.ts <nest> <title> [options]
+  if (wantsHelp(args)) {
+    printHelpAndExit(NOTEBOOK_HELP);
+  }
 
-Arguments:
-  nest    Diary channel nest (e.g., diary/~host/channel-name)
-  title   Post title
-
-Options:
-  --image <url>     Cover image URL
-  --content <file>  JSON file with Story JSON
-  --stdin           Read Story JSON from stdin
-  --markdown <file> Markdown file to convert to Story
-  --markdown-stdin  Read Markdown from stdin
-
-If no content is provided, creates a post with a title and empty body.
-
-Examples:
-  npx ts-node scripts/notebook-post.ts diary/~host/notes "Hello World"
-  npx ts-node scripts/notebook-post.ts diary/~host/notes "My Post" --image https://example.com/img.png
-  echo '[{"inline":["Hello!"]}]' | npx ts-node scripts/notebook-post.ts diary/~host/notes "Test" --stdin
-  npx ts-node scripts/notebook-post.ts diary/~host/notes "Markdown Post" --markdown post.md
-`);
-    process.exit(args.includes("--help") || args.includes("-h") ? 0 : 1);
+  if (args.length < 2) {
+    printUsageAndExit(NOTEBOOK_HELP);
   }
 
   const nest = args[0];
@@ -161,7 +171,4 @@ Examples:
 }
 
 main()
-  .catch((err) => {
-    console.error("Error:", err);
-    process.exit(1);
-  });
+  .catch(printErrorAndExit);

--- a/scripts/notebook-post.ts
+++ b/scripts/notebook-post.ts
@@ -23,7 +23,7 @@ import type { Story } from "@tloncorp/api";
 import { ensureClient } from "./api-client";
 import {
   getRequiredOptionValue,
-  isHelpArg,
+  isCommandHelpRequest,
   printErrorAndExit,
   printHelpAndExit,
   printUsageAndExit,
@@ -57,10 +57,6 @@ Examples:
   tlon notebook diary/~host/notes "My Post" --image https://example.com/img.png
   echo '[{"inline":["Hello!"]}]' | tlon notebook diary/~host/notes "Test" --stdin
   tlon notebook diary/~host/notes "Markdown Post" --markdown post.md`;
-
-function isNotebookHelpRequest(args: string[]): boolean {
-  return args.length === 1 && isHelpArg(args[0]);
-}
 
 function toApiStory(content: NotebookStory): Story {
   return content as unknown as Story;
@@ -99,7 +95,7 @@ export async function postToNotebook(
 async function main() {
   const args = process.argv.slice(2);
 
-  if (isNotebookHelpRequest(args)) {
+  if (isCommandHelpRequest(args)) {
     printHelpAndExit(NOTEBOOK_HELP);
   }
 

--- a/scripts/notebook-post.ts
+++ b/scripts/notebook-post.ts
@@ -23,10 +23,10 @@ import type { Story } from "@tloncorp/api";
 import { ensureClient } from "./api-client";
 import {
   getRequiredOptionValue,
+  isHelpArg,
   printErrorAndExit,
   printHelpAndExit,
   printUsageAndExit,
-  wantsHelp,
 } from "./cli-utils";
 import { normalizeNotebookContent, type NotebookStory } from "./notebook-content";
 import { markdownToStory } from "./story";
@@ -57,6 +57,10 @@ Examples:
   tlon notebook diary/~host/notes "My Post" --image https://example.com/img.png
   echo '[{"inline":["Hello!"]}]' | tlon notebook diary/~host/notes "Test" --stdin
   tlon notebook diary/~host/notes "Markdown Post" --markdown post.md`;
+
+function isNotebookHelpRequest(args: string[]): boolean {
+  return args.length === 1 && isHelpArg(args[0]);
+}
 
 function toApiStory(content: NotebookStory): Story {
   return content as unknown as Story;
@@ -95,7 +99,7 @@ export async function postToNotebook(
 async function main() {
   const args = process.argv.slice(2);
 
-  if (wantsHelp(args)) {
+  if (isNotebookHelpRequest(args)) {
     printHelpAndExit(NOTEBOOK_HELP);
   }
 

--- a/scripts/posts.ts
+++ b/scripts/posts.ts
@@ -18,7 +18,76 @@ import * as fs from "fs";
 import { addReaction, deletePost, editPost, getChannelPosts, getCurrentUserId, removeReaction } from "@tloncorp/api";
 import type { Post } from "@tloncorp/api";
 import { ensureClient } from "./api-client";
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
 import { markdownToStory, type Story } from "./story";
+
+const POSTS_HELP = `Usage: tlon posts <command>
+
+Note: Sending and replying to posts is handled by the Tlon channel plugin.
+
+Commands:
+  react <channel> <post-id> <emoji>     React to a post with an emoji
+  unreact <channel> <post-id>           Remove your reaction from a post
+  edit <channel> <post-id> <message>    Edit a post [--title <t>] [--image <url>] [--content <json>]
+  delete <channel> <post-id>            Delete a post
+
+Edit options:
+  --title <title>      Set/update notebook post title
+  --image <url>        Set/update cover image (notebooks)
+  --content <file>     Use Story JSON file for rich content (notebooks)
+
+Examples:
+  tlon posts edit chat/~host/channel 170.141... "Updated message"
+  tlon posts edit diary/~host/notes 170.141... --title "New Title" --image https://example.com/cover.jpg --content article.json
+
+Channel format: chat/~host/channel-name, diary/~host/name, heap/~host/name
+Use 'tlon messages channel <nest> --limit N' to see post IDs.`;
+
+const POSTS_COMMAND_HELP: Record<string, string> = {
+  react: "Usage: tlon posts react <channel> <post-id> <emoji>",
+  unreact: "Usage: tlon posts unreact <channel> <post-id>",
+  edit: "Usage: tlon posts edit <channel> <post-id> <message> [--title <title>] [--image <url>] [--content <json-file>]",
+  delete: "Usage: tlon posts delete <channel> <post-id>",
+  send: "error: Channel post send is handled by the Tlon channel plugin.\nUse the channel message tool with channel=tlon instead.",
+  reply: "error: Channel post reply is handled by the Tlon channel plugin.\nUse the channel message tool with channel=tlon and replyTo instead.",
+};
+
+function getPostsHelp(command?: string): string {
+  return command ? POSTS_COMMAND_HELP[command] ?? POSTS_HELP : POSTS_HELP;
+}
+
+function validatePostsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !POSTS_COMMAND_HELP[command]) {
+    printUsageAndExit(POSTS_HELP);
+  }
+
+  switch (command) {
+    case "react": {
+      if (!args[1] || !args[2] || !args[3]) printUsageAndExit(POSTS_COMMAND_HELP.react);
+      return;
+    }
+    case "unreact":
+    case "delete": {
+      if (!args[1] || !args[2]) printUsageAndExit(POSTS_COMMAND_HELP[command]);
+      return;
+    }
+    case "edit": {
+      if (!args[1] || !args[2]) printUsageAndExit(POSTS_COMMAND_HELP.edit);
+      return;
+    }
+    case "send":
+    case "reply": {
+      printUsageAndExit(POSTS_COMMAND_HELP[command]);
+    }
+  }
+}
 
 // Strip optional ~ship/ prefix from a post ID, returning just the numeric part
 function extractNumericId(id: string): string {
@@ -184,6 +253,16 @@ async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
+  if (isHelpArg(command)) {
+    printHelpAndExit(POSTS_HELP);
+  }
+
+  if (wantsHelp(args.slice(1))) {
+    printHelpAndExit(getPostsHelp(command));
+  }
+
+  validatePostsArgs(args);
+
   await ensureClient(['channels']);
 
   try {
@@ -191,8 +270,7 @@ async function main() {
       case "react": {
         const [_, channel, postId, emoji] = args;
         if (!channel || !postId || !emoji) {
-          console.error("Usage: posts.ts react <channel> <post-id> <emoji>");
-          process.exit(1);
+          printUsageAndExit(POSTS_COMMAND_HELP.react);
         }
         const result = await reactToPost(channel, postId, emoji);
         if (!result.success) {
@@ -206,8 +284,7 @@ async function main() {
       case "unreact": {
         const [_, channel, postId] = args;
         if (!channel || !postId) {
-          console.error("Usage: posts.ts unreact <channel> <post-id>");
-          process.exit(1);
+          printUsageAndExit(POSTS_COMMAND_HELP.unreact);
         }
         const result = await unreactToPost(channel, postId);
         if (!result.success) {
@@ -236,8 +313,7 @@ async function main() {
         const newImage = imageIdx !== -1 ? args[imageIdx + 1] : undefined;
         
         if (!channel || !postId) {
-          console.error("Usage: posts.ts edit <channel> <post-id> [message] [--title <title>] [--image <url>] [--content <json-file>]");
-          process.exit(1);
+          printUsageAndExit(POSTS_COMMAND_HELP.edit);
         }
 
         // Fetch existing post to preserve metadata not being explicitly changed
@@ -261,8 +337,7 @@ async function main() {
           // Plain text/markdown message
           const message = args.slice(3, flagStart).join(" ");
           if (!message) {
-            console.error("Usage: posts.ts edit <channel> <post-id> <message> [--title <title>] [--image <url>] [--content <json-file>]");
-            process.exit(1);
+            printUsageAndExit(POSTS_COMMAND_HELP.edit);
           }
           result = await editChannelPost(channel, postId, message, metadata);
         }
@@ -279,8 +354,7 @@ async function main() {
         const channel = args[1];
         const postId = args[2];
         if (!channel || !postId) {
-          console.error("Usage: posts.ts delete <channel> <post-id>");
-          process.exit(1);
+          printUsageAndExit(POSTS_COMMAND_HELP.delete);
         }
         const result = await deleteChannelPost(channel, postId);
         if (!result.success) {
@@ -292,49 +366,19 @@ async function main() {
       }
 
       case "send":
-        console.error("error: Channel post send is handled by the Tlon channel plugin.");
-        console.error("Use the channel message tool with channel=tlon instead.");
-        process.exit(1);
+        printUsageAndExit(POSTS_COMMAND_HELP.send);
         break;
 
       case "reply":
-        console.error("error: Channel post reply is handled by the Tlon channel plugin.");
-        console.error("Use the channel message tool with channel=tlon and replyTo instead.");
-        process.exit(1);
+        printUsageAndExit(POSTS_COMMAND_HELP.reply);
         break;
 
       default:
-        console.log(`Usage: posts.ts <command>
-
-Note: Sending and replying to posts is handled by the Tlon channel plugin.
-
-Commands:
-  react <channel> <post-id> <emoji>     React to a post with an emoji
-  unreact <channel> <post-id>           Remove your reaction from a post
-  edit <channel> <post-id> <message>    Edit a post [--title <t>] [--image <url>] [--content <json>]
-  delete <channel> <post-id>            Delete a post
-
-Edit options:
-  --title <title>      Set/update notebook post title
-  --image <url>        Set/update cover image (notebooks)
-  --content <file>     Use Story JSON file for rich content (notebooks)
-
-Examples:
-  # Edit with plain text
-  tlon posts edit chat/~host/channel 170.141... "Updated message"
-  
-  # Edit notebook with rich Story JSON and new cover image
-  tlon posts edit diary/~host/notes 170.141... --title "New Title" --image https://example.com/cover.jpg --content article.json
-
-Channel format: chat/~host/channel-name, diary/~host/name, heap/~host/name
-Use 'tlon messages channel <nest> --limit N' to see post IDs.
-`);
-        process.exit(1);
+        printUsageAndExit(POSTS_HELP);
     }
     process.exit(0);
-  } catch (error: any) {
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
+  } catch (error) {
+    printErrorAndExit(error);
   }
 }
 

--- a/scripts/posts.ts
+++ b/scripts/posts.ts
@@ -62,15 +62,30 @@ const POSTS_UNSUPPORTED_COMMAND_ERRORS: Record<string, string> = {
   reply: "Channel post reply is handled by the Tlon channel plugin.\nUse the channel message tool with channel=tlon and replyTo instead.",
 };
 
+const POST_EDIT_OPTION_FLAGS = ["title", "content", "image"] as const;
+
 function getPostsHelp(command?: string): string {
   return command ? POSTS_COMMAND_HELP[command] ?? POSTS_HELP : POSTS_HELP;
 }
 
 function firstPostEditFlagIndex(args: string[]): number {
-  const flagIndexes = ["--title", "--content", "--image"]
-    .map((flag) => args.indexOf(flag))
+  const flagIndexes = POST_EDIT_OPTION_FLAGS
+    .map((flag) => args.indexOf(`--${flag}`))
     .filter((idx) => idx !== -1);
   return flagIndexes.length > 0 ? Math.min(...flagIndexes) : args.length;
+}
+
+function getPostEditMessage(args: string[]): string {
+  return args.slice(3, firstPostEditFlagIndex(args)).join(" ");
+}
+
+function isPostEditMessageHelpLiteral(args: string[]): boolean {
+  return (
+    args[0] === "edit" &&
+    !!args[1] &&
+    !!args[2] &&
+    wantsHelp(args.slice(3, firstPostEditFlagIndex(args)))
+  );
 }
 
 function validatePostsArgs(args: string[]): void {
@@ -97,8 +112,8 @@ function validatePostsArgs(args: string[]): void {
     }
     case "edit": {
       if (!args[1] || !args[2]) printUsageAndExit(POSTS_COMMAND_HELP.edit);
-      const message = args.slice(3, firstPostEditFlagIndex(args)).join(" ");
-      if (!message && !hasOptionValue(args, "content")) {
+      const message = getPostEditMessage(args);
+      if (!message && !hasOptionValue(args, "content", POST_EDIT_OPTION_FLAGS)) {
         printUsageAndExit(POSTS_COMMAND_HELP.edit);
       }
       return;
@@ -274,7 +289,7 @@ async function main() {
     printHelpAndExit(POSTS_HELP);
   }
 
-  if (wantsHelp(args.slice(1))) {
+  if (wantsHelp(args.slice(1)) && !isPostEditMessageHelpLiteral(args)) {
     printHelpAndExit(getPostsHelp(command));
   }
 
@@ -319,12 +334,6 @@ async function main() {
         const contentIdx = args.indexOf("--content");
         const imageIdx = args.indexOf("--image");
         
-        // Find where flags start
-        let flagStart = args.length;
-        if (titleIdx !== -1 && titleIdx < flagStart) flagStart = titleIdx;
-        if (contentIdx !== -1 && contentIdx < flagStart) flagStart = contentIdx;
-        if (imageIdx !== -1 && imageIdx < flagStart) flagStart = imageIdx;
-        
         const newTitle = titleIdx !== -1 ? args[titleIdx + 1] : undefined;
         const contentFile = contentIdx !== -1 ? args[contentIdx + 1] : undefined;
         const newImage = imageIdx !== -1 ? args[imageIdx + 1] : undefined;
@@ -352,7 +361,7 @@ async function main() {
           result = await editChannelPostWithContent(channel, postId, content, metadata);
         } else {
           // Plain text/markdown message
-          const message = args.slice(3, flagStart).join(" ");
+          const message = getPostEditMessage(args);
           if (!message) {
             printUsageAndExit(POSTS_COMMAND_HELP.edit);
           }

--- a/scripts/posts.ts
+++ b/scripts/posts.ts
@@ -19,6 +19,7 @@ import { addReaction, deletePost, editPost, getChannelPosts, getCurrentUserId, r
 import type { Post } from "@tloncorp/api";
 import { ensureClient } from "./api-client";
 import {
+  hasOptionValue,
   isHelpArg,
   printErrorAndExit,
   printHelpAndExit,
@@ -54,17 +55,33 @@ const POSTS_COMMAND_HELP: Record<string, string> = {
   unreact: "Usage: tlon posts unreact <channel> <post-id>",
   edit: "Usage: tlon posts edit <channel> <post-id> <message> [--title <title>] [--image <url>] [--content <json-file>]",
   delete: "Usage: tlon posts delete <channel> <post-id>",
-  send: "error: Channel post send is handled by the Tlon channel plugin.\nUse the channel message tool with channel=tlon instead.",
-  reply: "error: Channel post reply is handled by the Tlon channel plugin.\nUse the channel message tool with channel=tlon and replyTo instead.",
+};
+
+const POSTS_UNSUPPORTED_COMMAND_ERRORS: Record<string, string> = {
+  send: "Channel post send is handled by the Tlon channel plugin.\nUse the channel message tool with channel=tlon instead.",
+  reply: "Channel post reply is handled by the Tlon channel plugin.\nUse the channel message tool with channel=tlon and replyTo instead.",
 };
 
 function getPostsHelp(command?: string): string {
   return command ? POSTS_COMMAND_HELP[command] ?? POSTS_HELP : POSTS_HELP;
 }
 
+function firstPostEditFlagIndex(args: string[]): number {
+  const flagIndexes = ["--title", "--content", "--image"]
+    .map((flag) => args.indexOf(flag))
+    .filter((idx) => idx !== -1);
+  return flagIndexes.length > 0 ? Math.min(...flagIndexes) : args.length;
+}
+
 function validatePostsArgs(args: string[]): void {
   const command = args[0];
-  if (!command || !POSTS_COMMAND_HELP[command]) {
+  if (!command) {
+    printUsageAndExit(POSTS_HELP);
+  }
+  if (POSTS_UNSUPPORTED_COMMAND_ERRORS[command]) {
+    printErrorAndExit(POSTS_UNSUPPORTED_COMMAND_ERRORS[command]);
+  }
+  if (!POSTS_COMMAND_HELP[command]) {
     printUsageAndExit(POSTS_HELP);
   }
 
@@ -80,11 +97,11 @@ function validatePostsArgs(args: string[]): void {
     }
     case "edit": {
       if (!args[1] || !args[2]) printUsageAndExit(POSTS_COMMAND_HELP.edit);
+      const message = args.slice(3, firstPostEditFlagIndex(args)).join(" ");
+      if (!message && !hasOptionValue(args, "content")) {
+        printUsageAndExit(POSTS_COMMAND_HELP.edit);
+      }
       return;
-    }
-    case "send":
-    case "reply": {
-      printUsageAndExit(POSTS_COMMAND_HELP[command]);
     }
   }
 }
@@ -366,12 +383,10 @@ async function main() {
       }
 
       case "send":
-        printUsageAndExit(POSTS_COMMAND_HELP.send);
-        break;
+        printErrorAndExit(POSTS_UNSUPPORTED_COMMAND_ERRORS.send);
 
       case "reply":
-        printUsageAndExit(POSTS_COMMAND_HELP.reply);
-        break;
+        printErrorAndExit(POSTS_UNSUPPORTED_COMMAND_ERRORS.reply);
 
       default:
         printUsageAndExit(POSTS_HELP);

--- a/scripts/posts.ts
+++ b/scripts/posts.ts
@@ -382,14 +382,6 @@ async function main() {
         break;
       }
 
-      case "send":
-        printErrorAndExit(POSTS_UNSUPPORTED_COMMAND_ERRORS.send);
-
-      case "reply":
-        printErrorAndExit(POSTS_UNSUPPORTED_COMMAND_ERRORS.reply);
-
-      default:
-        printUsageAndExit(POSTS_HELP);
     }
     process.exit(0);
   } catch (error) {

--- a/scripts/settings.ts
+++ b/scripts/settings.ts
@@ -14,9 +14,104 @@
 
 import { poke, scry } from "@tloncorp/api";
 import { ensureClient, normalizeShip } from "./api-client";
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from "./cli-utils";
 
 const SETTINGS_DESK = 'moltbot';
 const SETTINGS_BUCKET = 'tlon';
+
+const SETTINGS_HELP = `Usage: tlon settings <command>
+
+Commands:
+  get                              Show all settings
+  set <key> <json>                 Set a setting value
+  delete <key>                     Delete a setting
+
+  allow-dm <ship>                  Add ship to DM allowlist
+  remove-dm <ship>                 Remove ship from DM allowlist
+
+  allow-channel <nest>             Add channel to watched list
+  remove-channel <nest>            Remove channel from watched list
+
+  open-channel <nest>              Set channel to open mode (anyone can interact)
+  restrict-channel <nest> [ships]  Set channel to restricted mode
+
+  authorize-ship <ship>            Add to default authorized ships
+  deauthorize-ship <ship>          Remove from default authorized ships
+
+Examples:
+  tlon settings allow-dm ~nocsyx-lassul
+  tlon settings open-channel chat/~nocsyx-lassul/bongtable
+  tlon settings set showModelSig true`;
+
+const SETTINGS_COMMAND_HELP: Record<string, string> = {
+  get: "Usage: tlon settings get",
+  set: "Usage: tlon settings set <key> <json-value>",
+  delete: "Usage: tlon settings delete <key>",
+  del: "Usage: tlon settings delete <key>",
+  "allow-dm": "Usage: tlon settings allow-dm <ship>",
+  "add-dm": "Usage: tlon settings allow-dm <ship>",
+  "remove-dm": "Usage: tlon settings remove-dm <ship>",
+  "allow-channel": "Usage: tlon settings allow-channel <channel-nest>",
+  "add-channel": "Usage: tlon settings allow-channel <channel-nest>",
+  "remove-channel": "Usage: tlon settings remove-channel <channel-nest>",
+  "open-channel": "Usage: tlon settings open-channel <channel-nest>",
+  "restrict-channel": "Usage: tlon settings restrict-channel <channel-nest> [ships...]",
+  "set-rule": "Usage: tlon settings set-rule <channel-nest> <open|restricted> [ships...]",
+  "authorize-ship": "Usage: tlon settings authorize-ship <ship>",
+  "add-auth": "Usage: tlon settings authorize-ship <ship>",
+  "deauthorize-ship": "Usage: tlon settings deauthorize-ship <ship>",
+  "remove-auth": "Usage: tlon settings deauthorize-ship <ship>",
+};
+
+function getSettingsHelp(command?: string): string {
+  return command ? SETTINGS_COMMAND_HELP[command] ?? SETTINGS_HELP : SETTINGS_HELP;
+}
+
+function validateSettingsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !SETTINGS_COMMAND_HELP[command]) {
+    printUsageAndExit(SETTINGS_HELP);
+  }
+
+  switch (command) {
+    case "get":
+      return;
+    case "set": {
+      if (!args[1] || args[2] === undefined) printUsageAndExit(SETTINGS_COMMAND_HELP.set);
+      return;
+    }
+    case "delete":
+    case "del":
+    case "allow-dm":
+    case "add-dm":
+    case "remove-dm":
+    case "allow-channel":
+    case "add-channel":
+    case "remove-channel":
+    case "open-channel":
+    case "restrict-channel":
+    case "authorize-ship":
+    case "add-auth":
+    case "deauthorize-ship":
+    case "remove-auth": {
+      if (!args[1]) printUsageAndExit(SETTINGS_COMMAND_HELP[command]);
+      return;
+    }
+    case "set-rule": {
+      const mode = args[2];
+      if (!args[1] || !mode || (mode !== "open" && mode !== "restricted")) {
+        printUsageAndExit(SETTINGS_COMMAND_HELP["set-rule"]);
+      }
+      return;
+    }
+  }
+}
 
 async function getSettings(): Promise<Record<string, unknown>> {
   try {
@@ -128,9 +223,21 @@ async function setChannelRule(
 }
 
 async function main() {
-  const [,, command, ...args] = process.argv;
+  const rawArgs = process.argv.slice(2);
+  const command = rawArgs[0];
+  const args = rawArgs.slice(1);
   
   try {
+    if (isHelpArg(command)) {
+      printHelpAndExit(SETTINGS_HELP);
+    }
+
+    if (wantsHelp(args)) {
+      printHelpAndExit(getSettingsHelp(command));
+    }
+
+    validateSettingsArgs(rawArgs);
+
     await ensureClient();
     switch (command) {
       case 'get': {
@@ -142,8 +249,7 @@ async function main() {
       case 'set': {
         const [key, jsonValue] = args;
         if (!key || jsonValue === undefined) {
-          console.error('Usage: settings set <key> <json-value>');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP.set);
         }
         const value = JSON.parse(jsonValue);
         await putEntry(key, value);
@@ -154,8 +260,7 @@ async function main() {
       case 'del': {
         const [key] = args;
         if (!key) {
-          console.error('Usage: settings delete <key>');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP.delete);
         }
         await delEntry(key);
         break;
@@ -165,8 +270,7 @@ async function main() {
       case 'add-dm': {
         const [ship] = args;
         if (!ship) {
-          console.error('Usage: settings allow-dm <ship>');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP["allow-dm"]);
         }
         await addToArray('dmAllowlist', ship);
         break;
@@ -175,8 +279,7 @@ async function main() {
       case 'remove-dm': {
         const [ship] = args;
         if (!ship) {
-          console.error('Usage: settings remove-dm <ship>');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP["remove-dm"]);
         }
         await removeFromArray('dmAllowlist', ship);
         break;
@@ -186,8 +289,7 @@ async function main() {
       case 'add-channel': {
         const [channel] = args;
         if (!channel) {
-          console.error('Usage: settings allow-channel <channel-nest>');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP["allow-channel"]);
         }
         await addToArray('groupChannels', channel);
         break;
@@ -196,8 +298,7 @@ async function main() {
       case 'remove-channel': {
         const [channel] = args;
         if (!channel) {
-          console.error('Usage: settings remove-channel <channel-nest>');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP["remove-channel"]);
         }
         await removeFromArray('groupChannels', channel);
         break;
@@ -206,8 +307,7 @@ async function main() {
       case 'open-channel': {
         const [channel] = args;
         if (!channel) {
-          console.error('Usage: settings open-channel <channel-nest>');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP["open-channel"]);
         }
         await setChannelRule(channel, 'open');
         console.log(`✓ Opened ${channel} to all`);
@@ -217,8 +317,7 @@ async function main() {
       case 'restrict-channel': {
         const [channel, ...ships] = args;
         if (!channel) {
-          console.error('Usage: settings restrict-channel <channel-nest> [ships...]');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP["restrict-channel"]);
         }
         await setChannelRule(channel, 'restricted', ships.length ? ships : undefined);
         console.log(`✓ Restricted ${channel}${ships.length ? ` to ${ships.join(', ')}` : ''}`);
@@ -228,8 +327,7 @@ async function main() {
       case 'set-rule': {
         const [channel, mode, ...ships] = args;
         if (!channel || !mode || (mode !== 'open' && mode !== 'restricted')) {
-          console.error('Usage: settings set-rule <channel-nest> <open|restricted> [ships...]');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP["set-rule"]);
         }
         await setChannelRule(channel, mode as 'open' | 'restricted', ships.length ? ships : undefined);
         break;
@@ -239,8 +337,7 @@ async function main() {
       case 'add-auth': {
         const [ship] = args;
         if (!ship) {
-          console.error('Usage: settings authorize-ship <ship>');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP["authorize-ship"]);
         }
         await addToArray('defaultAuthorizedShips', ship);
         break;
@@ -250,38 +347,14 @@ async function main() {
       case 'remove-auth': {
         const [ship] = args;
         if (!ship) {
-          console.error('Usage: settings deauthorize-ship <ship>');
-          process.exit(1);
+          printUsageAndExit(SETTINGS_COMMAND_HELP["deauthorize-ship"]);
         }
         await removeFromArray('defaultAuthorizedShips', ship);
         break;
       }
       
       default:
-        console.log(`OpenClaw Settings Manager
-
-Commands:
-  get                              Show all settings
-  set <key> <json>                 Set a setting value
-  delete <key>                     Delete a setting
-  
-  allow-dm <ship>                  Add ship to DM allowlist
-  remove-dm <ship>                 Remove ship from DM allowlist
-  
-  allow-channel <nest>             Add channel to watched list
-  remove-channel <nest>            Remove channel from watched list
-  
-  open-channel <nest>              Set channel to open mode (anyone can interact)
-  restrict-channel <nest> [ships]  Set channel to restricted mode
-  
-  authorize-ship <ship>            Add to default authorized ships
-  deauthorize-ship <ship>          Remove from default authorized ships
-
-Examples:
-  npx ts-node scripts/settings.ts allow-dm ~nocsyx-lassul
-  npx ts-node scripts/settings.ts open-channel chat/~nocsyx-lassul/bongtable
-  npx ts-node scripts/settings.ts set showModelSig true
-`);
+        printUsageAndExit(SETTINGS_HELP);
     }
     process.exit(0);
   } finally {
@@ -289,7 +362,4 @@ Examples:
   }
 }
 
-main().catch((err) => {
-  console.error('Error:', err.message);
-  process.exit(1);
-});
+main().catch(printErrorAndExit);

--- a/scripts/upload.ts
+++ b/scripts/upload.ts
@@ -18,8 +18,27 @@ import * as fs from "fs";
 import * as path from "path";
 import { uploadFile } from "@tloncorp/api";
 import { ensureClient } from "./api-client";
+import { printHelpAndExit, printUsageAndExit } from "./cli-utils";
 
 const DEFAULT_CONTENT_TYPE = "application/octet-stream";
+const UPLOAD_HELP = `Usage: tlon upload <url-or-path> [options]
+       tlon upload --stdin [-t mime/type]
+
+Upload a file to Tlon storage from a URL, local path, or stdin.
+Outputs the uploaded URL on success.
+
+Options:
+  --stdin         Read binary data from stdin instead of a file/URL
+  -t, --type      Override content type (e.g., image/png, application/pdf)
+  -h, --help      Show this help
+
+Examples:
+  tlon upload https://example.com/image.png
+  tlon upload ./photo.jpg
+  tlon upload ~/Pictures/screenshot.png
+  tlon upload ./mystery-file -t image/webp
+  cat image.png | tlon upload --stdin -t image/png
+  curl -s https://example.com/img.jpg | tlon upload --stdin -t image/jpeg`;
 
 /** Common extension → MIME type mappings (no external dependency needed) */
 const MIME_TYPES: Record<string, string> = {
@@ -156,20 +175,23 @@ export async function main(args: string[]) {
     const arg = args[i];
     if (arg === "--stdin") {
       stdinMode = true;
-    } else if ((arg === "-t" || arg === "--type") && args[i + 1]) {
+    } else if (arg === "-t" || arg === "--type") {
+      if (!args[i + 1] || args[i + 1].startsWith("-")) {
+        printUsageAndExit(`Error: ${arg} requires a value\n\n${UPLOAD_HELP}`);
+      }
       contentType = args[i + 1];
       i++;
     } else if (arg === "--help" || arg === "-h") {
-      printHelp();
-      process.exit(0);
+      printHelpAndExit(UPLOAD_HELP);
+    } else if (arg.startsWith("-")) {
+      printUsageAndExit(`Error: Unknown option: ${arg}\n\n${UPLOAD_HELP}`);
     } else {
       positional.push(arg);
     }
   }
 
   if (!stdinMode && positional.length === 0) {
-    printHelp();
-    process.exit(1);
+    printUsageAndExit(UPLOAD_HELP);
   }
 
   await ensureClient();
@@ -190,25 +212,4 @@ export async function main(args: string[]) {
 
   console.log(uploadedUrl);
   process.exit(0);
-}
-
-function printHelp() {
-  console.log(`Usage: upload <url-or-path> [options]
-       upload --stdin [-t mime/type]
-
-Upload a file to Tlon storage from a URL, local path, or stdin.
-Outputs the uploaded URL on success.
-
-Options:
-  --stdin         Read binary data from stdin instead of a file/URL
-  -t, --type      Override content type (e.g., image/png, application/pdf)
-  -h, --help      Show this help
-
-Examples:
-  tlon upload https://example.com/image.png
-  tlon upload ./photo.jpg
-  tlon upload ~/Pictures/screenshot.png
-  tlon upload ./mystery-file -t image/webp
-  cat image.png | tlon upload --stdin -t image/png
-  curl -s https://example.com/img.jpg | tlon upload --stdin -t image/jpeg`);
 }

--- a/tests/hermetic/cli.test.ts
+++ b/tests/hermetic/cli.test.ts
@@ -196,6 +196,34 @@ const literalOptionLikeValueCommands = [
     name: "channels rename title",
     args: ["channels", "rename", "chat/~host/channel", "--roadmap"],
   },
+  {
+    name: "channels update title",
+    args: ["channels", "update", "chat/~host/channel", "--title", "--help"],
+  },
+  {
+    name: "groups create title",
+    args: ["groups", "create", "--roadmap"],
+  },
+  {
+    name: "groups create-owned title",
+    args: ["groups", "create-owned", "--roadmap", "--owner", "~zod"],
+  },
+  {
+    name: "groups update title",
+    args: ["groups", "update", "~host/group", "--title", "--help"],
+  },
+  {
+    name: "groups add-channel title",
+    args: ["groups", "add-channel", "~host/group", "--announcements"],
+  },
+  {
+    name: "hooks edit name",
+    args: ["hooks", "edit", "0v1a", "--name", "--help"],
+  },
+  {
+    name: "notebook title",
+    args: ["notebook", "diary/~host/notes", "--help"],
+  },
 ];
 
 describe("CLI hermetic subprocess behavior", () => {
@@ -245,7 +273,7 @@ describe("CLI hermetic subprocess behavior", () => {
       const result = await runCli(command.args);
 
       expect(result.exitCode).toBe(1);
-      expect(result.stdout).toBe("");
+      expect(result.stdout).not.toContain("Usage:");
       expect(result.stderr).not.toContain("Usage:");
       expect(result.stderr).toContain("Missing Urbit config");
     });

--- a/tests/hermetic/cli.test.ts
+++ b/tests/hermetic/cli.test.ts
@@ -181,6 +181,10 @@ const literalOptionLikeValueCommands = [
     args: ["posts", "edit", "chat/~host/channel", "170.141", "use", "--help"],
   },
   {
+    name: "messages search query",
+    args: ["messages", "search", "--channel", "--channel", "chat/~host/channel"],
+  },
+  {
     name: "contacts update-profile value",
     args: ["contacts", "update-profile", "--status", "--help"],
   },
@@ -223,6 +227,22 @@ const literalOptionLikeValueCommands = [
   {
     name: "notebook title",
     args: ["notebook", "diary/~host/notes", "--help"],
+  },
+  {
+    name: "contacts update-profile empty value",
+    args: ["contacts", "update-profile", "--status", ""],
+  },
+  {
+    name: "contacts update empty value",
+    args: ["contacts", "update", "~zod", "--nickname", ""],
+  },
+  {
+    name: "channels update empty value",
+    args: ["channels", "update", "chat/~host/channel", "--description", ""],
+  },
+  {
+    name: "groups update empty value",
+    args: ["groups", "update", "~host/group", "--description", ""],
   },
 ];
 

--- a/tests/hermetic/cli.test.ts
+++ b/tests/hermetic/cli.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import {
+  CLI_MATRIX_CASES,
+  COMMAND_FAMILIES,
+  type CliCase,
+  normalizeCliOutput,
+} from "../../scripts/cli-test-matrix";
 
 const rootDir = resolve(process.cwd());
 const cleanupPaths: string[] = [];
+const CLI_TIMEOUT_MS = 15_000;
 
 type RunContext = {
   tempRoot: string;
@@ -84,13 +91,28 @@ async function runCli(args: string[], options: RunOptions = {}): Promise<CliResu
       }
     );
 
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, CLI_TIMEOUT_MS);
+
     const [stdout, stderr, exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
     ]);
+    clearTimeout(timeout);
 
-    return { exitCode, stdout, stderr };
+    if (timedOut) {
+      throw new Error(`CLI timed out after ${CLI_TIMEOUT_MS}ms: ${args.join(" ")}`);
+    }
+
+    return {
+      exitCode,
+      stdout: normalizeCliOutput(stdout),
+      stderr: normalizeCliOutput(stderr),
+    };
   } finally {
     prepared.cleanup?.();
   }
@@ -105,76 +127,36 @@ afterEach(() => {
   }
 });
 
-function expectHelp(result: CliResult) {
-  expect(result.exitCode).toBe(0);
-  expect(result.stdout).toContain("Usage:");
-  expect(result.stderr).toBe("");
+function expectCliCase(result: CliResult, testCase: CliCase) {
+  expect(result.exitCode).toBe(testCase.expectedExitCode);
+
+  if (testCase.stdout !== undefined) {
+    expect(result.stdout).toBe(testCase.stdout);
+  }
+  for (const expected of testCase.stdoutIncludes ?? []) {
+    expect(result.stdout).toContain(expected);
+  }
+  for (const unexpected of testCase.stdoutExcludes ?? []) {
+    expect(result.stdout).not.toContain(unexpected);
+  }
+
+  if (testCase.stderr !== undefined) {
+    expect(result.stderr).toBe(testCase.stderr);
+  }
+  for (const expected of testCase.stderrIncludes ?? []) {
+    expect(result.stderr).toContain(expected);
+  }
+  for (const unexpected of testCase.stderrExcludes ?? []) {
+    expect(result.stderr).not.toContain(unexpected);
+  }
 }
 
-const helpCommands = [
+const hostileHelpCommands = [
   { name: "top-level", args: ["--help"] },
-  { name: "upload", args: ["upload", "--help"] },
-  { name: "activity", args: ["activity", "--help"] },
-];
-
-const hostileHelpVariants: Array<{
-  name: string;
-  prepare?: RunOptions["prepare"];
-  env?: Record<string, string>;
-}> = [
-  {
-    name: "nonexistent TLON_CONFIG_FILE",
-    prepare: ({ home }) => ({
-      env: { TLON_CONFIG_FILE: join(home, "missing-ship.json") },
-    }),
-  },
-  {
-    name: "CLI --config /nonexistent",
-    prepare: ({ home }) => ({
-      argsPrefix: ["--config", join(home, "missing-ship.json")],
-    }),
-  },
-  {
-    name: "invalid OPENCLAW_CONFIG",
-    prepare: ({ home }) => {
-      const configPath = join(home, "invalid-openclaw.json");
-      writeFileSync(configPath, "{not-json");
-      return { env: { OPENCLAW_CONFIG: configPath } };
-    },
-  },
-  {
-    name: "multiple cached ships",
-    prepare: ({ cacheDir }) => {
-      writeFileSync(
-        join(cacheDir, "zod.json"),
-        JSON.stringify({
-          url: "https://zod.example",
-          ship: "zod",
-          cookie: "urbauth-~zod=fake",
-        })
-      );
-      writeFileSync(
-        join(cacheDir, "bus.json"),
-        JSON.stringify({
-          url: "https://bus.example",
-          ship: "bus",
-          cookie: "urbauth-~bus=fake",
-        })
-      );
-    },
-  },
-  {
-    name: "unwritable cache path",
-    prepare: ({ tempRoot }) => {
-      const cacheDir = join(tempRoot, "unwritable-cache");
-      mkdirSync(cacheDir);
-      chmodSync(cacheDir, 0o500);
-      return {
-        cacheDir,
-        cleanup: () => chmodSync(cacheDir, 0o700),
-      };
-    },
-  },
+  ...COMMAND_FAMILIES.map((family) => ({
+    name: family,
+    args: [family, "--help"],
+  })),
 ];
 
 describe("CLI hermetic subprocess behavior", () => {
@@ -186,25 +168,36 @@ describe("CLI hermetic subprocess behavior", () => {
     expect(result.stderr).toBe("");
   });
 
-  for (const command of helpCommands) {
-    for (const variant of hostileHelpVariants) {
-      it(`prints ${command.name} help with ${variant.name}`, async () => {
-        const result = await runCli(command.args, {
-          env: variant.env,
-          prepare: variant.prepare,
-        });
-
-        expectHelp(result);
-      });
-    }
+  for (const testCase of CLI_MATRIX_CASES) {
+    it(testCase.name, async () => {
+      const result = await runCli(testCase.args);
+      expectCliCase(result, testCase);
+    });
   }
 
-  it("reports unknown commands without reading credentials", async () => {
-    const result = await runCli(["definitely-not-a-command"]);
+  for (const command of hostileHelpCommands) {
+    it(`prints ${command.name} help with nonexistent TLON_CONFIG_FILE`, async () => {
+      const result = await runCli(command.args, {
+        prepare: ({ home }) => ({
+          env: { TLON_CONFIG_FILE: join(home, "missing-ship.json") },
+        }),
+      });
 
-    expect(result.exitCode).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("Unknown command: definitely-not-a-command");
-    expect(result.stderr).toContain('Run "tlon --help" for usage information.');
-  });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Usage:");
+      expect(result.stderr).toBe("");
+    });
+
+    it(`prints ${command.name} help with CLI --config /nonexistent`, async () => {
+      const result = await runCli(command.args, {
+        prepare: ({ home }) => ({
+          argsPrefix: ["--config", join(home, "missing-ship.json")],
+        }),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Usage:");
+      expect(result.stderr).toBe("");
+    });
+  }
 });

--- a/tests/hermetic/cli.test.ts
+++ b/tests/hermetic/cli.test.ts
@@ -167,6 +167,21 @@ const hostileHelpCommands = [
   })),
 ];
 
+const literalHelpMessageCommands = [
+  {
+    name: "dms send message",
+    args: ["dms", "send", "0v123", "use", "--help"],
+  },
+  {
+    name: "dms reply message",
+    args: ["dms", "reply", "0v123", "~zod/170.141", "use", "--help"],
+  },
+  {
+    name: "posts edit message",
+    args: ["posts", "edit", "chat/~host/channel", "170.141", "use", "--help"],
+  },
+];
+
 describe("CLI hermetic subprocess behavior", () => {
   it("prints source CLI version without host credentials", async () => {
     const result = await runCli(["--version"]);
@@ -206,6 +221,17 @@ describe("CLI hermetic subprocess behavior", () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Usage:");
       expect(result.stderr).toBe("");
+    });
+  }
+
+  for (const command of literalHelpMessageCommands) {
+    it(`does not treat ${command.name} literal --help as command help`, async () => {
+      const result = await runCli(command.args);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).not.toContain("Usage:");
+      expect(result.stderr).toContain("Missing Urbit config");
     });
   }
 });

--- a/tests/hermetic/cli.test.ts
+++ b/tests/hermetic/cli.test.ts
@@ -100,12 +100,21 @@ async function runCli(args: string[], options: RunOptions = {}): Promise<CliResu
     const timeoutFailure = new Promise<never>((_, reject) => {
       timeout = setTimeout(() => {
         proc.kill("SIGKILL");
+        output.catch(() => {});
         reject(new Error(`CLI timed out after ${CLI_TIMEOUT_MS}ms: ${args.join(" ")}`));
       }, CLI_TIMEOUT_MS);
     });
 
-    const [stdout, stderr, exitCode] = await Promise.race([output, timeoutFailure]);
-    if (timeout) clearTimeout(timeout);
+    let stdout: string;
+    let stderr: string;
+    let exitCode: number;
+    try {
+      [stdout, stderr, exitCode] = await Promise.race([output, timeoutFailure]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
 
     return {
       exitCode,

--- a/tests/hermetic/cli.test.ts
+++ b/tests/hermetic/cli.test.ts
@@ -91,22 +91,21 @@ async function runCli(args: string[], options: RunOptions = {}): Promise<CliResu
       }
     );
 
-    let timedOut = false;
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      proc.kill();
-    }, CLI_TIMEOUT_MS);
-
-    const [stdout, stderr, exitCode] = await Promise.all([
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const output = Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
     ]);
-    clearTimeout(timeout);
+    const timeoutFailure = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        proc.kill("SIGKILL");
+        reject(new Error(`CLI timed out after ${CLI_TIMEOUT_MS}ms: ${args.join(" ")}`));
+      }, CLI_TIMEOUT_MS);
+    });
 
-    if (timedOut) {
-      throw new Error(`CLI timed out after ${CLI_TIMEOUT_MS}ms: ${args.join(" ")}`);
-    }
+    const [stdout, stderr, exitCode] = await Promise.race([output, timeoutFailure]);
+    if (timeout) clearTimeout(timeout);
 
     return {
       exitCode,

--- a/tests/hermetic/cli.test.ts
+++ b/tests/hermetic/cli.test.ts
@@ -167,7 +167,7 @@ const hostileHelpCommands = [
   })),
 ];
 
-const literalHelpMessageCommands = [
+const literalOptionLikeValueCommands = [
   {
     name: "dms send message",
     args: ["dms", "send", "0v123", "use", "--help"],
@@ -179,6 +179,22 @@ const literalHelpMessageCommands = [
   {
     name: "posts edit message",
     args: ["posts", "edit", "chat/~host/channel", "170.141", "use", "--help"],
+  },
+  {
+    name: "contacts update-profile value",
+    args: ["contacts", "update-profile", "--status", "--help"],
+  },
+  {
+    name: "contacts update value",
+    args: ["contacts", "update", "~zod", "--nickname", "-h"],
+  },
+  {
+    name: "channels create title",
+    args: ["channels", "create", "~host/group", "--roadmap"],
+  },
+  {
+    name: "channels rename title",
+    args: ["channels", "rename", "chat/~host/channel", "--roadmap"],
   },
 ];
 
@@ -224,8 +240,8 @@ describe("CLI hermetic subprocess behavior", () => {
     });
   }
 
-  for (const command of literalHelpMessageCommands) {
-    it(`does not treat ${command.name} literal --help as command help`, async () => {
+  for (const command of literalOptionLikeValueCommands) {
+    it(`does not treat ${command.name} option-like value as local CLI syntax`, async () => {
       const result = await runCli(command.args);
 
       expect(result.exitCode).toBe(1);

--- a/tests/hermetic/cli.test.ts
+++ b/tests/hermetic/cli.test.ts
@@ -167,85 +167,6 @@ const hostileHelpCommands = [
   })),
 ];
 
-const literalOptionLikeValueCommands = [
-  {
-    name: "dms send message",
-    args: ["dms", "send", "0v123", "use", "--help"],
-  },
-  {
-    name: "dms reply message",
-    args: ["dms", "reply", "0v123", "~zod/170.141", "use", "--help"],
-  },
-  {
-    name: "posts edit message",
-    args: ["posts", "edit", "chat/~host/channel", "170.141", "use", "--help"],
-  },
-  {
-    name: "messages search query",
-    args: ["messages", "search", "--channel", "--channel", "chat/~host/channel"],
-  },
-  {
-    name: "contacts update-profile value",
-    args: ["contacts", "update-profile", "--status", "--help"],
-  },
-  {
-    name: "contacts update value",
-    args: ["contacts", "update", "~zod", "--nickname", "-h"],
-  },
-  {
-    name: "channels create title",
-    args: ["channels", "create", "~host/group", "--roadmap"],
-  },
-  {
-    name: "channels rename title",
-    args: ["channels", "rename", "chat/~host/channel", "--roadmap"],
-  },
-  {
-    name: "channels update title",
-    args: ["channels", "update", "chat/~host/channel", "--title", "--help"],
-  },
-  {
-    name: "groups create title",
-    args: ["groups", "create", "--roadmap"],
-  },
-  {
-    name: "groups create-owned title",
-    args: ["groups", "create-owned", "--roadmap", "--owner", "~zod"],
-  },
-  {
-    name: "groups update title",
-    args: ["groups", "update", "~host/group", "--title", "--help"],
-  },
-  {
-    name: "groups add-channel title",
-    args: ["groups", "add-channel", "~host/group", "--announcements"],
-  },
-  {
-    name: "hooks edit name",
-    args: ["hooks", "edit", "0v1a", "--name", "--help"],
-  },
-  {
-    name: "notebook title",
-    args: ["notebook", "diary/~host/notes", "--help"],
-  },
-  {
-    name: "contacts update-profile empty value",
-    args: ["contacts", "update-profile", "--status", ""],
-  },
-  {
-    name: "contacts update empty value",
-    args: ["contacts", "update", "~zod", "--nickname", ""],
-  },
-  {
-    name: "channels update empty value",
-    args: ["channels", "update", "chat/~host/channel", "--description", ""],
-  },
-  {
-    name: "groups update empty value",
-    args: ["groups", "update", "~host/group", "--description", ""],
-  },
-];
-
 describe("CLI hermetic subprocess behavior", () => {
   it("prints source CLI version without host credentials", async () => {
     const result = await runCli(["--version"]);
@@ -288,14 +209,4 @@ describe("CLI hermetic subprocess behavior", () => {
     });
   }
 
-  for (const command of literalOptionLikeValueCommands) {
-    it(`does not treat ${command.name} option-like value as local CLI syntax`, async () => {
-      const result = await runCli(command.args);
-
-      expect(result.exitCode).toBe(1);
-      expect(result.stdout).not.toContain("Usage:");
-      expect(result.stderr).not.toContain("Usage:");
-      expect(result.stderr).toContain("Missing Urbit config");
-    });
-  }
 });


### PR DESCRIPTION
## Summary

This PR expands the Phase 1A (PR #87) quality gate from a small CLI seed check into full no-config CLI coverage for the command surface.

The CLI now handles help, bare invocations, invalid subcommands, and representative missing-argument errors before trying to read config, cache, OpenClaw files, or initialize the Tlon API client. It also normalizes expected local CLI errors so source and compiled-binary output can be tested without brittle stack traces or script-era usage text.

## What Changed

- Normalized no-config help behavior across command families:
  - `activity`
  - `channels`
  - `contacts`
  - `dms`
  - `expose`
  - `groups`
  - `hooks`
  - `messages`
  - `notebook`
  - `posts`
  - `settings`
  - `upload`

- Moved local parser checks before auth/client setup for:
  - family `--help` and `-h`
  - bare family invocation
  - invalid subcommands
  - representative missing required arguments
  - `upload` unknown options
  - `notebook` unknown options

- Standardized expected local CLI output:
  - help exits `0`, writes usage to stdout, and keeps stderr empty
  - local usage errors exit nonzero, keep stdout empty, and write stable usage/error text to stderr
  - expected local errors avoid source excerpts, bundled line numbers, stack traces, and auth/config leakage

- Added a shared CLI matrix in `scripts/cli-test-matrix.ts` so source hermetic tests and built-binary smoke tests assert the same behavior.

- Expanded `tests/hermetic/cli.test.ts` to cover the no-config source CLI matrix with isolated env, temp home/cache paths, hostile config variants, timeouts, ANSI stripping, and normalized stdout/stderr assertions.

- Expanded `scripts/build-smoke.ts` so `npm run check` builds a fresh `dist/tlon-run` and runs the same no-config matrix against the compiled binary, including expected nonzero cases.

## Intentional Scope

This does not change credential precedence, extract the auth resolver, add live integration tests, or migrate commands to a `run(args, deps)` handler contract. Those remain later phases.

This also does not attempt exhaustive nested subcommand or alias coverage. Phase 1B covers representative nested help and verifies the top-level no-config behavior that CI should protect.

## Verification

Ran locally:

```sh
npm run typecheck
npm run test:integration
npm run build:smoke
```

The implementation reviewer also reported these passing:

```sh
npm ci
npm run test:unit
npm test
npm run check
npm run test:coverage
git diff --check
```