### PR TITLE
Migrate posts react to pure command runner

### DIFF
--- a/scripts/cli-test-matrix.ts
+++ b/scripts/cli-test-matrix.ts
@@ -272,9 +272,39 @@ export const NESTED_HELP_CASES: CliCase[] = [
     ["groups", "info", "--help"],
     "Usage: tlon groups info"
   ),
+  helpCase(
+    "posts react --help",
+    ["posts", "react", "--help"],
+    "Usage: tlon posts react"
+  ),
+  helpCase(
+    "posts react --help with global credentials",
+    [
+      "--url",
+      "https://cli.tlon.network",
+      "--cookie",
+      "urbauth-~zod=0v-cookie",
+      "posts",
+      "react",
+      "--help",
+    ],
+    "Usage: tlon posts react"
+  ),
+  helpCase(
+    "posts unreact --help",
+    ["posts", "unreact", "--help"],
+    "Usage: tlon posts unreact"
+  ),
 ];
 
 export const LITERAL_OPTION_LIKE_VALUE_CASES: CliCase[] = [
+  authRequiredCase("posts react valid args reaches auth", [
+    "posts",
+    "react",
+    "chat/~host/channel",
+    "170.141",
+    "👍",
+  ]),
   authRequiredCase("dms send message option-like value reaches auth", [
     "dms",
     "send",

--- a/scripts/commands/posts.test.ts
+++ b/scripts/commands/posts.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "bun:test";
+import {
+  POSTS_REACT_HELP,
+  type PostReactionInput,
+  type PostsDeps,
+  run,
+} from "./posts";
+import { commandError } from "./command";
+
+function makeDeps(options: {
+  currentUserId?: string;
+  authenticate?: () => Promise<void>;
+  addReaction?: (input: PostReactionInput) => Promise<void>;
+} = {}) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const calls = {
+    authenticate: 0,
+    getCurrentUserId: 0,
+    addReaction: [] as PostReactionInput[],
+    order: [] as string[],
+  };
+
+  const deps: PostsDeps = {
+    stdout: (text) => stdout.push(text),
+    stderr: (text) => stderr.push(text),
+    authenticate: async () => {
+      calls.authenticate += 1;
+      calls.order.push("authenticate");
+      await options.authenticate?.();
+    },
+    getCurrentUserId: () => {
+      calls.getCurrentUserId += 1;
+      calls.order.push("getCurrentUserId");
+      return options.currentUserId ?? "~zod";
+    },
+    postsApi: {
+      addReaction: async (input) => {
+        calls.addReaction.push(input);
+        calls.order.push("addReaction");
+        await options.addReaction?.(input);
+      },
+    },
+  };
+
+  return {
+    deps,
+    calls,
+    stdout: () => stdout.join(""),
+    stderr: () => stderr.join(""),
+  };
+}
+
+describe("posts command run", () => {
+  it("prints react help without authenticating or calling the API", async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(["react", "--help"], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toBe(`${POSTS_REACT_HELP}\n`);
+    expect(context.stderr()).toBe("");
+    expect(context.calls.authenticate).toBe(0);
+    expect(context.calls.getCurrentUserId).toBe(0);
+    expect(context.calls.addReaction).toEqual([]);
+  });
+
+  it("prints react help for help tokens in positional slots", async () => {
+    const cases = [
+      ["react", "chat/~host/channel", "--help"],
+      ["react", "chat/~host/channel", "170.141", "-h"],
+      ["react", "chat/~host/channel", "170.141", "👍", "--help"],
+    ];
+
+    for (const args of cases) {
+      const context = makeDeps();
+      const exitCode = await run(args, context.deps);
+
+      expect(exitCode).toBe(0);
+      expect(context.stdout()).toBe(`${POSTS_REACT_HELP}\n`);
+      expect(context.stderr()).toBe("");
+      expect(context.calls.authenticate).toBe(0);
+      expect(context.calls.getCurrentUserId).toBe(0);
+      expect(context.calls.addReaction).toEqual([]);
+    }
+  });
+
+  it("fails missing react args before auth or API work", async () => {
+    const cases = [
+      ["react"],
+      ["react", "chat/~host/channel"],
+      ["react", "chat/~host/channel", "170.141"],
+    ];
+
+    for (const args of cases) {
+      const context = makeDeps();
+      const exitCode = await run(args, context.deps);
+
+      expect(exitCode).toBe(1);
+      expect(context.stdout()).toBe("");
+      expect(context.stderr()).toBe(`${POSTS_REACT_HELP}\n`);
+      expect(context.calls.authenticate).toBe(0);
+      expect(context.calls.getCurrentUserId).toBe(0);
+      expect(context.calls.addReaction).toEqual([]);
+    }
+  });
+
+  it("builds reaction payloads for dotted, undotted, and author-prefixed post ids", async () => {
+    const cases = [
+      { rawPostId: "170.141.184", expectedPostId: "170.141.184" },
+      { rawPostId: "170141184", expectedPostId: "170.141.184" },
+      { rawPostId: "~sampel/170141184", expectedPostId: "170.141.184" },
+    ];
+
+    for (const testCase of cases) {
+      const context = makeDeps({ currentUserId: "~bus" });
+      const exitCode = await run(
+        ["react", "chat/~host/channel", testCase.rawPostId, "👍"],
+        context.deps
+      );
+
+      expect(exitCode).toBe(0);
+      expect(context.calls.addReaction).toEqual([
+        {
+          channelId: "chat/~host/channel",
+          postId: testCase.expectedPostId,
+          emoji: "👍",
+          our: "~bus",
+          postAuthor: "~bus",
+        },
+      ]);
+    }
+  });
+
+  it("authenticates once, reads the current user once, and writes success output", async () => {
+    const context = makeDeps({ currentUserId: "~nec" });
+
+    const exitCode = await run(
+      ["react", "chat/~host/channel", "170141184", "🔥"],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toBe("✓ Reaction added\n");
+    expect(context.stderr()).toBe("");
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.getCurrentUserId).toBe(1);
+    expect(context.calls.addReaction).toHaveLength(1);
+    expect(context.calls.order).toEqual([
+      "authenticate",
+      "getCurrentUserId",
+      "addReaction",
+    ]);
+    expect(context.calls.addReaction[0]).toMatchObject({
+      channelId: "chat/~host/channel",
+      postId: "170.141.184",
+      emoji: "🔥",
+      our: "~nec",
+      postAuthor: "~nec",
+    });
+  });
+
+  it("ignores extra args after the emoji", async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(
+      ["react", "chat/~host/channel", "170141184", "👍", "ignored"],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toBe("✓ Reaction added\n");
+    expect(context.stderr()).toBe("");
+    expect(context.calls.addReaction).toHaveLength(1);
+    expect(context.calls.addReaction[0].emoji).toBe("👍");
+  });
+
+  it("formats expected facade failures through the shared command-error path", async () => {
+    const context = makeDeps({
+      addReaction: async () => {
+        throw commandError("reaction API unavailable");
+      },
+    });
+
+    const exitCode = await run(
+      ["react", "chat/~host/channel", "170141184", "👍"],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe("");
+    expect(context.stderr()).toBe("Error: reaction API unavailable\n");
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.getCurrentUserId).toBe(1);
+    expect(context.calls.addReaction).toHaveLength(1);
+  });
+
+  it("leaves unexpected exceptions for the adapter formatter", async () => {
+    const context = makeDeps({
+      addReaction: async () => {
+        throw new Error("unexpected reaction failure");
+      },
+    });
+
+    await expect(
+      run(["react", "chat/~host/channel", "170141184", "👍"], context.deps)
+    ).rejects.toThrow("unexpected reaction failure");
+
+    expect(context.stdout()).toBe("");
+    expect(context.stderr()).toBe("");
+  });
+});

--- a/scripts/commands/posts.ts
+++ b/scripts/commands/posts.ts
@@ -1,0 +1,107 @@
+import {
+  type CommandDeps,
+  handleExpectedCommandError,
+  isHelpArg,
+  usageError,
+  writeHelp,
+  writeLine,
+} from "./command";
+
+export const POSTS_REACT_HELP = "Usage: tlon posts react <channel> <post-id> <emoji>";
+
+export interface PostReactionInput {
+  channelId: string;
+  postId: string;
+  emoji: string;
+  our: string;
+  postAuthor: string;
+}
+
+export interface PostsApi {
+  addReaction: (input: PostReactionInput) => Promise<void>;
+}
+
+export interface PostsDeps extends CommandDeps {
+  authenticate: () => Promise<void>;
+  getCurrentUserId: () => string;
+  postsApi: PostsApi;
+}
+
+type ParsedPostsArgs =
+  | { kind: "help" }
+  | { kind: "react"; channelId: string; postId: string; emoji: string };
+
+function extractNumericId(id: string): string {
+  const slash = id.indexOf("/");
+  return slash >= 0 ? id.slice(slash + 1) : id;
+}
+
+function formatUd(id: string): string {
+  const clean = id.replace(/\./g, "");
+  const parts: string[] = [];
+  for (let i = clean.length; i > 0; i -= 3) {
+    parts.unshift(clean.slice(Math.max(0, i - 3), i));
+  }
+  return parts.join(".");
+}
+
+function formatPostId(postId: string): string {
+  return formatUd(extractNumericId(postId));
+}
+
+function parseArgs(args: string[]): ParsedPostsArgs {
+  const command = args[0];
+
+  if (command !== "react") {
+    throw usageError(POSTS_REACT_HELP);
+  }
+
+  if (args.slice(1).some(isHelpArg)) {
+    return { kind: "help" };
+  }
+
+  const channelId = args[1];
+  const postId = args[2];
+  const emoji = args[3];
+
+  if (!channelId || !postId || !emoji) {
+    throw usageError(POSTS_REACT_HELP);
+  }
+
+  return { kind: "react", channelId, postId, emoji };
+}
+
+async function reactToPost(
+  channelId: string,
+  postId: string,
+  emoji: string,
+  deps: PostsDeps
+): Promise<void> {
+  const our = deps.getCurrentUserId();
+  await deps.postsApi.addReaction({
+    channelId,
+    postId: formatPostId(postId),
+    emoji,
+    our,
+    postAuthor: our,
+  });
+}
+
+export async function run(args: string[], deps: PostsDeps): Promise<number> {
+  try {
+    const parsed = parseArgs(args);
+    if (parsed.kind === "help") {
+      return writeHelp(deps, POSTS_REACT_HELP);
+    }
+
+    await deps.authenticate();
+    await reactToPost(parsed.channelId, parsed.postId, parsed.emoji, deps);
+
+    writeLine(deps.stdout, "✓ Reaction added");
+    return 0;
+  } catch (error) {
+    const handled = handleExpectedCommandError(error, deps);
+    if (handled !== null) return handled;
+    throw error;
+  }
+}

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -21,8 +21,10 @@ import { setCliCredentialOverrides } from "./api-client";
 import { createActivityDeps } from "./activity-runtime";
 import { formatUnexpectedError } from "./commands/command";
 import { run as runActivityCommand } from "./commands/activity";
+import { run as runPostsCommand } from "./commands/posts";
 import { run as runUploadCommand } from "./commands/upload";
 import { CredentialFlagError, parseGlobalCliOptions } from "./credential-flags";
+import { createPostsDeps } from "./posts-runtime";
 import { isTopLevelCommand } from "./top-level-commands";
 import { createUploadDeps } from "./upload-runtime";
 
@@ -191,6 +193,11 @@ async function main() {
         break;
       }
       case "posts": {
+        if (scriptArgs[0] === "react") {
+          const exitCode = await runPostsCommand(scriptArgs, createPostsDeps());
+          process.exit(exitCode);
+          break;
+        }
         process.argv = ["tlon", command, ...scriptArgs];
         const mod = await import("./posts");
         break;

--- a/scripts/posts-runtime.ts
+++ b/scripts/posts-runtime.ts
@@ -1,0 +1,33 @@
+import {
+  addReaction as apiAddReaction,
+  getCurrentUserId as apiGetCurrentUserId,
+} from "@tloncorp/api";
+import { ensureClient } from "./api-client";
+import { commandError, errorMessage } from "./commands/command";
+import type { PostReactionInput, PostsDeps } from "./commands/posts";
+
+function createProcessCommandDeps() {
+  return {
+    stdout: (text: string) => process.stdout.write(text),
+    stderr: (text: string) => process.stderr.write(text),
+  };
+}
+
+export function createPostsDeps(): PostsDeps {
+  return {
+    ...createProcessCommandDeps(),
+    authenticate: async () => {
+      await ensureClient(["channels"]);
+    },
+    getCurrentUserId: () => apiGetCurrentUserId(),
+    postsApi: {
+      addReaction: async (input: PostReactionInput) => {
+        try {
+          await apiAddReaction(input);
+        } catch (error) {
+          throw commandError(errorMessage(error));
+        }
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Migrates `tlon posts react` to the pure command-runner architecture. Next PR will migrate everything, this is just demonstrating the shape/scale.

- Adds a pure `posts react` runner plus process-backed runtime deps.
- Routes only `posts react ...` through the new runner; all other `posts` paths stay on legacy dispatch.
- Preserves legacy reaction parsing, help behavior, payload formatting, and success output.
- Adds unit and source/built CLI coverage for the migrated path and a non-`react` legacy sentinel.

## Testing

- `npm run check`